### PR TITLE
Remove unnecessary createdAt date from sticky note display

### DIFF
--- a/retro-ai/components/board/sticky-note.tsx
+++ b/retro-ai/components/board/sticky-note.tsx
@@ -193,9 +193,6 @@ export function StickyNote({ sticky, userId }: StickyNoteProps) {
                 {sticky.author.name || sticky.author.email}
               </span>
             </div>
-            <span className="text-xs text-muted-foreground">
-              {sticky.createdAt.toLocaleDateString()}
-            </span>
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Removed the date display from sticky notes to reduce visual clutter
- Keeps focus on the sticky note content and author information

## Changes
- Removed 3 lines from `sticky-note.tsx` that displayed the creation date

## Test plan
- [x] Verified sticky notes display without the date
- [x] Confirmed no TypeScript errors
- [x] Existing lint warnings are unrelated to this change

Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)