### PR TITLE
Fix header padding - 'Retro AI' text too close to left margin

### DIFF
--- a/retro-ai/components/layout/header.tsx
+++ b/retro-ai/components/layout/header.tsx
@@ -25,7 +25,7 @@ export function Header() {
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center">
         <div className="flex flex-1 items-center justify-between">
-          <Link href="/dashboard" className="font-semibold text-xl">
+          <Link href="/dashboard" className="font-semibold text-xl ml-4">
             Retro AI
           </Link>
 


### PR DESCRIPTION
## Summary
- Added left margin to the 'Retro AI' link in the header for better visual spacing
- Improves alignment with container edges

## Changes
- Added `ml-4` class to the header link component

## Test plan
- [x] Verified the 'Retro AI' text now has proper left spacing
- [x] Confirmed no TypeScript errors
- [x] Existing lint warnings are unrelated to this change

Closes #42

🤖 Generated with [Claude Code](https://claude.ai/code)