### PR TITLE
Replace hardcoded localhost with environment variable in auth mock request

### DIFF
--- a/retro-ai/lib/auth.ts
+++ b/retro-ai/lib/auth.ts
@@ -141,7 +141,7 @@ export const authOptions: NextAuthOptions = {
             const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000); // 24 hours from now
             // Create a mock NextRequest for server-side session creation
             const mockHeaders = new Headers({ 'user-agent': 'NextAuth' });
-            const mockRequest = new Request('http://localhost', {
+            const mockRequest = new Request(process.env.NEXTAUTH_URL || 'http://localhost:3000', {
               headers: mockHeaders,
             });
             await SessionManager.createSession(


### PR DESCRIPTION
## Summary
Replaces hardcoded localhost URL with environment variable for better production deployment support.

## Changes
- Updated `lib/auth.ts` to use `process.env.NEXTAUTH_URL` instead of hardcoded `'http://localhost'`
- Added fallback to `'http://localhost:3000'` for local development
- Improved code maintainability by removing hardcoded values

## Technical Details
The mock request creation in the JWT callback now uses:
```typescript
const mockRequest = new Request(process.env.NEXTAUTH_URL || 'http://localhost:3000', {
  headers: mockHeaders,
});
```

This respects the configured application URL while maintaining a sensible default for development.

## Impact
- **Functional**: No change - the URL isn't actually used by SessionManager
- **Code Quality**: Removes hardcoded values, follows best practices
- **Deployment**: Better support for production environments with custom domains

## Test plan
- [x] Ran `npm run lint` - passes with no errors
- [x] Change maintains existing functionality
- [x] Environment variable fallback ensures local development works

Closes #49

🤖 Generated with [Claude Code](https://claude.ai/code)