### PR TITLE
Improve avatar initials to show first and last name initials consistently

### DIFF
--- a/retro-ai/components/board/editing-indicator.tsx
+++ b/retro-ai/components/board/editing-indicator.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils";
 
 interface EditingIndicatorProps {
   userName: string;
@@ -8,9 +9,7 @@ interface EditingIndicatorProps {
 }
 
 export function EditingIndicator({ userName, className = "" }: EditingIndicatorProps) {
-  const initials = userName
-    ? userName.charAt(0).toUpperCase()
-    : "?";
+  const initials = getInitials(userName) || "?";
 
   return (
     <div className={`absolute bottom-1 right-1 flex items-center gap-1 ${className}`}>

--- a/retro-ai/components/board/sticky-note.tsx
+++ b/retro-ai/components/board/sticky-note.tsx
@@ -7,6 +7,7 @@ import { CSS } from "@dnd-kit/utilities";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { getInitials } from "@/lib/utils";
 import { 
   DropdownMenu, 
   DropdownMenuContent, 
@@ -185,8 +186,8 @@ export function StickyNote({ sticky, userId }: StickyNoteProps) {
             <div className="flex items-center gap-2">
               <Avatar className="h-5 w-5">
                 <AvatarFallback className="text-xs">
-                  {sticky.author.name?.charAt(0).toUpperCase() || 
-                   sticky.author.email.charAt(0).toUpperCase()}
+                  {getInitials(sticky.author.name || '') || 
+                   getInitials(sticky.author.email) || "U"}
                 </AvatarFallback>
               </Avatar>
               <span className="text-xs text-muted-foreground">

--- a/retro-ai/components/layout/header.tsx
+++ b/retro-ai/components/layout/header.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { LogOut, Settings, User } from "lucide-react";
+import { getInitials } from "@/lib/utils";
 
 export function Header() {
   const { data: session, status } = useSession();
@@ -36,8 +37,8 @@ export function Header() {
                   <Button variant="ghost" className="relative h-9 w-9 rounded-full">
                     <Avatar className="h-9 w-9">
                       <AvatarFallback>
-                        {session.user.name?.charAt(0).toUpperCase() || 
-                         session.user.email?.charAt(0).toUpperCase() || "U"}
+                        {getInitials(session.user.name || '') || 
+                         getInitials(session.user.email || '') || "U"}
                       </AvatarFallback>
                     </Avatar>
                   </Button>

--- a/retro-ai/lib/auth.ts
+++ b/retro-ai/lib/auth.ts
@@ -2,6 +2,7 @@ import { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import bcrypt from "bcryptjs";
+import { NextRequest } from "next/server";
 import { prisma } from "./prisma";
 import { generateSecureSessionId } from "./cookie-security";
 import { SessionManager } from "./session-manager";

--- a/retro-ai/lib/utils.ts
+++ b/retro-ai/lib/utils.ts
@@ -4,3 +4,24 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Generates initials from a user's name
+ * @param name - The user's full name
+ * @returns Formatted initials (e.g., "JD" for "John Doe", "JO" for "John")
+ */
+export function getInitials(name: string): string {
+  if (!name || name.trim().length === 0) return '';
+  
+  const words = name.trim().split(/\s+/);
+  
+  if (words.length === 1) {
+    // Single word: return first two characters if available, otherwise first character
+    return words[0].substring(0, 2).toUpperCase();
+  }
+  
+  // Multiple words: return first character of first and last word
+  const firstInitial = words[0].charAt(0);
+  const lastInitial = words[words.length - 1].charAt(0);
+  return `${firstInitial}${lastInitial}`.toUpperCase();
+}


### PR DESCRIPTION
## Summary
Implements consistent avatar initials across all components, showing first + last name initials instead of just the first character.

## Changes Made
### ✅ Created Shared Utility
- Added `getInitials()` function to `/lib/utils.ts` 
- Handles multiple name formats with proper fallbacks
- Includes JSDoc documentation

### ✅ Updated All Avatar Components
- **Header dropdown**: Now uses shared utility
- **Sticky note authors**: Consistent initials logic
- **Editing indicators**: Uses shared utility (see note below)

### ✅ Behavior Improvements
 < /dev/null |  Input | Before | After |
|-------|---------|-------|
| "David Jones" | "D" | "DJ" |
| "John" | "J" | "JO" |  
| "Alice Bob Smith" | "A" | "AS" |
| `null`/empty | "U" | "U" |

## Technical Details
- **Multiple words**: First + last initial ("John Doe" → "JD")
- **Single word**: First 2 characters ("John" → "JO")
- **Edge cases**: Empty names handled with "U" fallback
- **Consistency**: All components use same shared logic

## Testing
- ✅ Header avatar shows correct initials
- ✅ Sticky note avatars show correct initials
- ✅ All ESLint checks pass
- ✅ TypeScript compilation clean

## Known Issue
Editing indicators currently show "US" due to WebSocket server hardcoding `userName: "User"`. This is a separate issue with the real-time collaboration system and will be addressed in issue #55.

## Files Modified
- `lib/utils.ts` - New shared utility
- `components/layout/header.tsx` - Uses shared utility
- `components/board/sticky-note.tsx` - Uses shared utility  
- `components/board/editing-indicator.tsx` - Uses shared utility
- `lib/auth.ts` - Fixed missing NextRequest import

Closes #37

🤖 Generated with [Claude Code](https://claude.ai/code)