### PR TITLE
Increase editing indicator avatar size to prevent initial clipping (issue #37 enhancement)

### DIFF
--- a/retro-ai/components/board/editing-indicator.tsx
+++ b/retro-ai/components/board/editing-indicator.tsx
@@ -14,7 +14,7 @@ export function EditingIndicator({ userName, className = "" }: EditingIndicatorP
   return (
     <div className={`absolute bottom-1 right-1 flex items-center gap-1 ${className}`}>
       {/* User avatar */}
-      <Avatar className="h-4 w-4 border border-white">
+      <Avatar className="h-6 w-6 border border-white">
         <AvatarFallback className="text-xs bg-gray-600 text-white">
           {initials}
         </AvatarFallback>


### PR DESCRIPTION
## Summary
- Increased editing indicator avatar size from 16px to 24px to prevent clipping of user initials
- Enhancement to the previously completed issue #37 (avatar initials improvement)

## Problem
The editing indicator avatars were too small (`h-4 w-4` = 16px) and were visually clipping the user initials, making them hard to read. This was particularly noticeable with two-character initials like "DJ" or "JS".

## Solution
- Changed avatar size from `h-4 w-4` (16px) to `h-6 w-6` (24px)
- Provides adequate space for two-character initials without clipping
- Maintains the same `text-xs` font size for consistency
- Keeps the same visual styling (gray background, white border)

## Visual Impact
**Before**: 16px avatar with potential clipping of initials
**After**: 24px avatar with clear, readable initials

## Files Changed
- `components/board/editing-indicator.tsx` - Updated avatar className

## Test plan
- [x] Build succeeds without errors
- [x] Lint passes without warnings
- [x] Development server starts successfully
- [ ] Manual test: editing indicators show larger, clearer avatars
- [ ] Manual test: initials are no longer clipped in the avatar circle

Enhancement to #37

🤖 Generated with [Claude Code](https://claude.ai/code)