### PR TITLE
Fix settings page missing header and navigation (issue #28)

### DIFF
--- a/retro-ai/app/(dashboard)/settings/page.tsx
+++ b/retro-ai/app/(dashboard)/settings/page.tsx
@@ -8,7 +8,7 @@ import { Shield, Users, Settings as SettingsIcon, Wifi } from 'lucide-react';
 
 export default function SettingsPage() {
   return (
-    <div className="container mx-auto py-6 space-y-6">
+    <div className="space-y-6">
       <div className="flex items-center space-x-2">
         <SettingsIcon className="h-6 w-6" />
         <h1 className="text-3xl font-bold">Settings</h1>


### PR DESCRIPTION
## Summary
- Fixed settings page missing header and navigation by moving it into the dashboard layout
- Settings page now has consistent navigation and header like other dashboard pages

## Problem
The settings page was located at `/app/settings/page.tsx` instead of `/app/(dashboard)/settings/page.tsx`, which meant it wasn't using the dashboard layout that provides the Header and Sidebar components. This left users without proper navigation when on the settings page.

## Solution
- **Moved settings page** from `/app/settings/` to `/app/(dashboard)/settings/`
- **Now uses dashboard layout** which automatically provides:
  - Header component with user avatar and navigation
  - Sidebar component with main navigation menu
  - Consistent styling and spacing with other dashboard pages
- **Removed redundant styling** - removed `container mx-auto py-6` classes since the dashboard layout handles spacing

## Visual Impact
**Before**: Settings page with no header/navigation - users trapped on settings with no easy way back  
**After**: Settings page with full header and sidebar navigation - consistent with rest of application

## Files Changed
- `app/(dashboard)/settings/page.tsx` - Moved from `app/settings/page.tsx`
- Minor styling adjustment to work with dashboard layout container

## Test plan
- [x] Build succeeds without errors
- [x] Lint passes without warnings  
- [x] Development server starts successfully
- [x] Settings route still accessible at `/settings`
- [x] Manual test: settings page shows header with user avatar
- [x] Manual test: settings page shows sidebar navigation
- [x] Manual test: can navigate away from settings using sidebar

Resolves #28

🤖 Generated with [Claude Code](https://claude.ai/code)