### PR TITLE
Improve sidebar navigation: highlight active routes including sub-routes (issue #34)

### DIFF
--- a/retro-ai/components/layout/sidebar.tsx
+++ b/retro-ai/components/layout/sidebar.tsx
@@ -44,6 +44,18 @@ const sidebarItems = [
 export function Sidebar() {
   const pathname = usePathname();
 
+  // Helper function to determine if a navigation item is active
+  const isActiveRoute = (href: string) => {
+    // Exact match for dashboard and settings
+    if (href === "/dashboard" || href === "/settings") {
+      return pathname === href;
+    }
+    
+    // For other routes, check if pathname starts with the href
+    // This handles sub-routes like /teams/new, /boards/123, etc.
+    return pathname.startsWith(href);
+  };
+
   return (
     <div className="flex h-full w-64 flex-col border-r bg-background">
       <div className="flex-1 space-y-4 py-4">
@@ -57,22 +69,25 @@ export function Sidebar() {
             </Button>
           </div>
           <div className="space-y-1">
-            {sidebarItems.map((item) => (
-              <Button
-                key={item.href}
-                variant={pathname === item.href ? "secondary" : "ghost"}
-                className={cn(
-                  "w-full justify-start",
-                  pathname === item.href && "bg-muted"
-                )}
-                asChild
-              >
+            {sidebarItems.map((item) => {
+              const isActive = isActiveRoute(item.href);
+              return (
+                <Button
+                  key={item.href}
+                  variant={isActive ? "secondary" : "ghost"}
+                  className={cn(
+                    "w-full justify-start",
+                    isActive && "bg-muted"
+                  )}
+                  asChild
+                >
                 <Link href={item.href}>
                   <item.icon className="mr-2 h-4 w-4" />
                   {item.title}
                 </Link>
-              </Button>
-            ))}
+                </Button>
+              );
+            })}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Enhanced sidebar navigation to highlight active routes including sub-routes
- Users can now see which main section they're in even when on sub-pages

## Problem
The sidebar navigation only highlighted exact route matches, so:
- When on `/teams/new` or `/teams/join`, the "Teams" nav item wasn't highlighted
- When on `/boards/new` or `/boards/[boardId]`, the "Boards" nav item wasn't highlighted  
- Users lost visual context of which main section they were navigating

## Solution
- **Added `isActiveRoute` helper function** with smart matching logic:
  - **Exact matching** for `/dashboard` and `/settings` (no sub-routes)
  - **Prefix matching** for `/teams` and `/boards` (to catch sub-routes)
- **Enhanced navigation highlighting**:
  - `/teams`, `/teams/new`, `/teams/join`, `/teams/[teamId]` → highlight "Teams"
  - `/boards`, `/boards/new`, `/boards/[boardId]` → highlight "Boards"
  - `/dashboard` → highlight "Dashboard" (exact match)
  - `/settings` → highlight "Settings" (exact match)

## Technical Implementation
```typescript
const isActiveRoute = (href: string) => {
  // Exact match for dashboard and settings  
  if (href === "/dashboard" || href === "/settings") {
    return pathname === href;
  }
  
  // For other routes, check if pathname starts with the href
  return pathname.startsWith(href);
};
```

## User Experience Improvement
**Before**: Users on `/teams/new` see no highlighted navigation - confusing  
**After**: Users on `/teams/new` see "Teams" highlighted - clear context

**Navigation Examples:**
- On `/teams/new` → "Teams" is highlighted ✅
- On `/boards/abc123` → "Boards" is highlighted ✅  
- On `/dashboard` → "Dashboard" is highlighted ✅
- On `/settings` → "Settings" is highlighted ✅

## Files Changed
- `components/layout/sidebar.tsx` - Enhanced active route detection logic

## Test plan
- [x] Build succeeds without errors
- [x] Lint passes without warnings
- [x] Development server starts successfully
- [x] Manual test: navigate to `/teams/new` - "Teams" should be highlighted
- [x] Manual test: navigate to `/boards/new` - "Boards" should be highlighted
- [x] Manual test: navigate to `/dashboard` - "Dashboard" should be highlighted
- [x] Manual test: navigate to `/settings` - "Settings" should be highlighted

Resolves #34

🤖 Generated with [Claude Code](https://claude.ai/code)