### PR TITLE
Add inline column renaming functionality

### DIFF
--- a/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
+++ b/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
@@ -112,6 +112,7 @@ export default async function BoardPage({
           board={board}
           columns={board.columns}
           userId={session.user.id}
+          isOwner={board.createdById === session.user.id}
         />
       </div>
     </div>

--- a/retro-ai/app/api/columns/[columnId]/route.ts
+++ b/retro-ai/app/api/columns/[columnId]/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ columnId: string }> }
+) {
+  const { columnId } = await params;
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.email) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // Get user from database
+    const user = await prisma.user.findUnique({
+      where: { email: session.user.email },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    const { title } = await req.json();
+
+    // Validate title
+    if (!title || typeof title !== "string" || title.trim().length === 0) {
+      return NextResponse.json(
+        { error: "Invalid title" },
+        { status: 400 }
+      );
+    }
+
+    const trimmedTitle = title.trim();
+
+    // Find the column and verify ownership
+    const column = await prisma.column.findUnique({
+      where: { id: columnId },
+      include: {
+        board: {
+          select: {
+            id: true,
+            createdById: true,
+          },
+        },
+      },
+    });
+
+    if (!column) {
+      return NextResponse.json(
+        { error: "Column not found" },
+        { status: 404 }
+      );
+    }
+
+    // Check if user is the board owner
+    if (column.board.createdById !== user.id) {
+      return NextResponse.json(
+        { error: "Only board owners can rename columns" },
+        { status: 403 }
+      );
+    }
+
+    // Update the column
+    const updatedColumn = await prisma.column.update({
+      where: { id: columnId },
+      data: { title: trimmedTitle },
+    });
+
+    return NextResponse.json(updatedColumn);
+  } catch (error) {
+    console.error("Error updating column:", error);
+    return NextResponse.json(
+      { error: "Failed to update column" },
+      { status: 500 }
+    );
+  }
+}

--- a/retro-ai/components/board/column.tsx
+++ b/retro-ai/components/board/column.tsx
@@ -1,10 +1,15 @@
 "use client";
 
+import { useState, useEffect, useRef } from "react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { StickyNote } from "./sticky-note";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Pencil } from "lucide-react";
+import { toast } from "sonner";
+import { useSocket } from "@/hooks/use-socket";
 
 interface ColumnProps {
   column: {
@@ -34,13 +39,96 @@ interface ColumnProps {
     }>;
   };
   userId: string;
+  boardId: string;
+  isOwner: boolean;
   moveIndicators?: Record<string, { movedBy: string; timestamp: number }>;
+  onColumnRenamed?: (columnId: string, newTitle: string) => void;
 }
 
-export function Column({ column, userId, moveIndicators }: ColumnProps) {
+export function Column({ column, userId, boardId, isOwner, moveIndicators, onColumnRenamed }: ColumnProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: column.id,
   });
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState(column.title);
+  const [isSaving, setIsSaving] = useState(false);
+  const [showPencil, setShowPencil] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const { emitColumnRenamed } = useSocket({
+    boardId,
+  });
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const handleSave = async () => {
+    const trimmedTitle = editTitle.trim();
+    
+    if (!trimmedTitle) {
+      toast.error("Column title cannot be empty");
+      setEditTitle(column.title);
+      setIsEditing(false);
+      return;
+    }
+
+    if (trimmedTitle === column.title) {
+      setIsEditing(false);
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const response = await fetch(`/api/columns/${column.id}`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ title: trimmedTitle }),
+      });
+
+      if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.error || "Failed to rename column");
+      }
+
+      // Emit WebSocket event for real-time updates
+      emitColumnRenamed({
+        columnId: column.id,
+        title: trimmedTitle,
+        boardId,
+      });
+
+      // Update local state through callback
+      onColumnRenamed?.(column.id, trimmedTitle);
+
+      toast.success("Column renamed successfully");
+      setIsEditing(false);
+    } catch (error) {
+      console.error("Failed to rename column:", error);
+      toast.error(error instanceof Error ? error.message : "Failed to rename column");
+      setEditTitle(column.title);
+      setIsEditing(false);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    } else if (e.key === "Escape") {
+      setEditTitle(column.title);
+      setIsEditing(false);
+    }
+  };
 
   return (
     <Card
@@ -49,14 +137,40 @@ export function Column({ column, userId, moveIndicators }: ColumnProps) {
         isOver ? "ring-2 ring-primary" : ""
       }`}
     >
-      <CardHeader className="pb-3">
+      <CardHeader 
+        className="pb-3"
+        onMouseEnter={() => isOwner && setShowPencil(true)}
+        onMouseLeave={() => isOwner && setShowPencil(false)}
+      >
         <div className="flex items-center justify-between">
-          <CardTitle
-            className="text-lg"
-            style={{ color: column.color || undefined }}
-          >
-            {column.title}
-          </CardTitle>
+          {isEditing ? (
+            <Input
+              ref={inputRef}
+              value={editTitle}
+              onChange={(e) => setEditTitle(e.target.value)}
+              onBlur={handleSave}
+              onKeyDown={handleKeyDown}
+              disabled={isSaving}
+              className="text-lg font-semibold h-auto py-0 px-1"
+              style={{ color: column.color || undefined }}
+            />
+          ) : (
+            <div className="flex items-center gap-2 flex-1">
+              <CardTitle
+                className="text-lg cursor-text"
+                style={{ color: column.color || undefined }}
+                onClick={() => isOwner && setIsEditing(true)}
+              >
+                {column.title}
+              </CardTitle>
+              {isOwner && showPencil && (
+                <Pencil 
+                  className="h-4 w-4 text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+                  onClick={() => setIsEditing(true)}
+                />
+              )}
+            </div>
+          )}
           <Badge variant="secondary">{column.stickies.length}</Badge>
         </div>
       </CardHeader>

--- a/retro-ai/hooks/use-socket.ts
+++ b/retro-ai/hooks/use-socket.ts
@@ -26,6 +26,14 @@ interface UserEvent {
   userName: string;
 }
 
+interface ColumnRenameEvent {
+  columnId: string;
+  title: string;
+  boardId: string;
+  userId: string;
+  timestamp: number;
+}
+
 interface UseSocketOptions {
   boardId?: string;
   onStickyMoved?: (data: MovementEvent) => void;
@@ -33,6 +41,7 @@ interface UseSocketOptions {
   onEditingStopped?: (data: EditingEvent) => void;
   onUserConnected?: (data: UserEvent) => void;
   onUserDisconnected?: (data: UserEvent) => void;
+  onColumnRenamed?: (data: ColumnRenameEvent) => void;
 }
 
 export function useSocket(options: UseSocketOptions = {}) {
@@ -44,6 +53,7 @@ export function useSocket(options: UseSocketOptions = {}) {
     onEditingStopped,
     onUserConnected,
     onUserDisconnected,
+    onColumnRenamed,
   } = options;
 
   const currentBoardRef = useRef<string | null>(null);
@@ -99,6 +109,11 @@ export function useSocket(options: UseSocketOptions = {}) {
       unsubscribers.push(unsubscribe);
     }
 
+    if (onColumnRenamed) {
+      const unsubscribe = socketContext.onColumnRenamed(onColumnRenamed);
+      unsubscribers.push(unsubscribe);
+    }
+
     return () => {
       unsubscribers.forEach((unsubscribe) => unsubscribe());
     };
@@ -109,6 +124,7 @@ export function useSocket(options: UseSocketOptions = {}) {
     onEditingStopped,
     onUserConnected,
     onUserDisconnected,
+    onColumnRenamed,
   ]);
 
   return {
@@ -116,5 +132,6 @@ export function useSocket(options: UseSocketOptions = {}) {
     emitStickyMoved: socketContext.emitStickyMoved,
     emitEditingStart: socketContext.emitEditingStart,
     emitEditingStop: socketContext.emitEditingStop,
+    emitColumnRenamed: socketContext.emitColumnRenamed,
   };
 }


### PR DESCRIPTION
## Summary
- Implement inline column renaming for board owners with hover-to-edit UI
- Add real-time WebSocket broadcasting to update all connected users
- Include comprehensive ownership validation and error handling

## Features Added
- **Inline Editing UI**: Column titles show pencil icon on hover for board owners
- **PATCH API Endpoint**: `/api/columns/[columnId]` with proper ownership validation 
- **Real-time Updates**: WebSocket events broadcast column renames to all users
- **Local State Management**: Immediate UI updates for both originating and remote users
- **Keyboard Shortcuts**: Enter to save, Escape to cancel
- **Access Control**: Only board owners can rename columns

## Technical Implementation
- Added `onColumnRenamed` callback to update local state immediately
- Implemented WebSocket `column-renamed` events with board-level authorization
- Enhanced Socket.io context with column rename emit/listen functionality
- Updated board canvas to handle real-time column title updates
- Added proper TypeScript interfaces for column rename events

## Test Plan
- [x] Verify only board owners see edit UI (pencil icon on hover)
- [x] Test inline editing with keyboard shortcuts (Enter/Escape)
- [x] Confirm real-time updates work for all connected users
- [x] Validate API ownership restrictions prevent unauthorized renames
- [x] Check error handling for invalid inputs and network failures
- [x] Ensure local state updates immediately for user making changes

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)