### PR TITLE
Redesign homepage with integrated login form (Shadcn login-02 style)

### DIFF
--- a/retro-ai/app/(auth)/register/page.tsx
+++ b/retro-ai/app/(auth)/register/page.tsx
@@ -52,7 +52,7 @@ export default function RegisterPage() {
       }
 
       toast.success("Account created successfully! Please sign in.");
-      router.push("/login");
+      router.push("/");
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "An error occurred");
     } finally {
@@ -124,7 +124,7 @@ export default function RegisterPage() {
             </Button>
             <p className="text-sm text-center text-muted-foreground">
               Already have an account?{" "}
-              <Link href="/login" className="text-primary hover:underline">
+              <Link href="/" className="text-primary hover:underline">
                 Sign in
               </Link>
             </p>

--- a/retro-ai/app/page.tsx
+++ b/retro-ai/app/page.tsx
@@ -1,26 +1,23 @@
+import { LoginForm } from "@/components/auth/login-form";
+
 export default function Home() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center">
-      <main className="flex flex-col items-center gap-8 text-center">
-        <h1 className="text-6xl font-bold">Retro AI</h1>
-        <p className="text-xl text-muted-foreground">
-          Agile retrospectives made simple
-        </p>
-        <div className="flex gap-4">
-          <a
-            href="/login"
-            className="rounded-md bg-primary px-6 py-3 text-primary-foreground hover:bg-primary/90"
-          >
-            Get Started
-          </a>
-          <a
-            href="/about"
-            className="rounded-md border border-input px-6 py-3 hover:bg-accent"
-          >
-            Learn More
-          </a>
+    <div className="min-h-screen flex items-center justify-center bg-background">
+      <div className="mx-auto max-w-sm space-y-6">
+        <div className="space-y-2 text-center">
+          <h1 className="text-3xl font-bold">Retro AI</h1>
+          <p className="text-muted-foreground">
+            Collaborative retrospectives for agile teams
+          </p>
         </div>
-      </main>
+        <div className="space-y-2 text-center">
+          <h2 className="text-2xl font-bold">Login</h2>
+          <p className="text-muted-foreground">
+            Enter your email below to login to your account
+          </p>
+        </div>
+        <LoginForm showTitle={false} showSignUpLink={true} />
+      </div>
     </div>
   );
 }

--- a/retro-ai/components/auth/login-form.tsx
+++ b/retro-ai/components/auth/login-form.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { toast } from "sonner";
+import { AlertTriangle, Shield } from "lucide-react";
+
+interface LoginFormProps {
+  className?: string;
+  showTitle?: boolean;
+  showSignUpLink?: boolean;
+}
+
+export function LoginForm({ 
+  className = "", 
+  showTitle = true, 
+  showSignUpLink = true 
+}: LoginFormProps) {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const router = useRouter();
+
+  // Get error from URL params (from middleware redirects) using window.location
+  const [error, setError] = useState<string | null>(null);
+  
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const urlParams = new URLSearchParams(window.location.search);
+      setError(urlParams.get('error'));
+    }
+  }, []);
+
+  // Get security error message
+  const getSecurityErrorMessage = (errorType: string | null) => {
+    switch (errorType) {
+      case 'SecurityThreat':
+        return {
+          title: 'Security Alert',
+          message: 'Your session was terminated due to suspicious activity. Please log in again.',
+          icon: <Shield className="h-4 w-4" />,
+          variant: 'destructive' as const
+        };
+      case 'SessionExpired':
+        return {
+          title: 'Session Expired',
+          message: 'Your session has expired for security reasons. Please log in again.',
+          icon: <AlertTriangle className="h-4 w-4" />,
+          variant: 'default' as const
+        };
+      case 'SessionValidationError':
+        return {
+          title: 'Session Error',
+          message: 'There was an issue validating your session. Please log in again.',
+          icon: <AlertTriangle className="h-4 w-4" />,
+          variant: 'default' as const
+        };
+      default:
+        return null;
+    }
+  };
+
+  const securityError = getSecurityErrorMessage(error);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsLoading(true);
+
+    try {
+      const result = await signIn("credentials", {
+        email,
+        password,
+        redirect: false,
+      });
+
+      if (result?.error) {
+        toast.error("Invalid email or password");
+      } else if (result?.ok) {
+        console.log("Login successful, redirecting to dashboard");
+        router.push("/dashboard");
+        router.refresh();
+      }
+    } catch (error) {
+      console.error("Login error:", error);
+      toast.error("An error occurred. Please try again.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Card className={`w-full max-w-sm ${className}`}>
+      {showTitle && (
+        <CardHeader>
+          <CardTitle className="text-2xl">Login</CardTitle>
+          <CardDescription>
+            Enter your email below to login to your account
+          </CardDescription>
+        </CardHeader>
+      )}
+      <form onSubmit={handleSubmit}>
+        <CardContent className="grid gap-4">
+          {securityError && (
+            <Alert variant={securityError.variant}>
+              <div className="flex items-center gap-2">
+                {securityError.icon}
+                <div>
+                  <p className="font-medium">{securityError.title}</p>
+                  <AlertDescription>{securityError.message}</AlertDescription>
+                </div>
+              </div>
+            </Alert>
+          )}
+          <div className="grid gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="m@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={isLoading}
+            />
+          </div>
+          <div className="grid gap-2">
+            <div className="flex items-center">
+              <Label htmlFor="password">Password</Label>
+              <Link href="#" className="ml-auto inline-block text-sm underline">
+                Forgot your password?
+              </Link>
+            </div>
+            <Input
+              id="password"
+              type="password"
+              placeholder="Enter your password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              disabled={isLoading}
+            />
+          </div>
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? "Signing in..." : "Login"}
+          </Button>
+          {showSignUpLink && (
+            <div className="mt-4 text-center text-sm">
+              Don&apos;t have an account?{" "}
+              <Link href="/register" className="underline">
+                Sign up
+              </Link>
+            </div>
+          )}
+        </CardContent>
+      </form>
+    </Card>
+  );
+}

--- a/retro-ai/lib/auth.ts
+++ b/retro-ai/lib/auth.ts
@@ -56,7 +56,7 @@ export const authOptions: NextAuthOptions = {
     },
   },
   pages: {
-    signIn: "/login",
+    signIn: "/",
   },
   providers: [
     CredentialsProvider({


### PR DESCRIPTION
## Summary
Replaces the current homepage "Get Started" and "Learn More" buttons with an integrated login form styled after the Shadcn UI login-02 block design, creating a streamlined user experience.

## Changes Made

### 🎨 UI/UX Improvements
- **Homepage redesign**: Replaced generic buttons with integrated login form
- **Shadcn login-02 styling**: Clean, centered layout with card design
- **Responsive design**: Works seamlessly on mobile and desktop
- **Theme support**: Maintains light/dark theme compatibility

### 🔧 Technical Implementation
- **Reusable component**: Created `LoginForm` component extracted from existing login page
- **Flexible props**: Supports `showTitle` and `showSignUpLink` for different contexts
- **Authentication flow**: Maintains all existing NextAuth functionality
- **Error handling**: Preserves security error alerts and form validation

### 🔄 Navigation Updates
- **NextAuth configuration**: Updated signIn page from `/login` to `/`
- **Register page**: Updated redirect and links to point to homepage
- **Consistent routing**: Streamlined authentication flow

## Files Modified
- `app/page.tsx` - New homepage with integrated login
- `components/auth/login-form.tsx` - New reusable login component
- `lib/auth.ts` - Updated NextAuth signIn page configuration
- `app/(auth)/register/page.tsx` - Updated links to homepage

## Testing
- ✅ Authentication flow works correctly
- ✅ Responsive design on mobile and desktop
- ✅ Light/dark theme support
- ✅ Error handling and validation preserved
- ✅ All linting issues resolved

## Design Reference
Based on Shadcn UI login-02 block with:
- Minimalist, centered login form
- Clean typography and spacing
- Subtle borders and shadows
- Professional authentication experience

Closes #43

🤖 Generated with [Claude Code](https://claude.ai/code)