### PR TITLE
Fix Docker build failure with Prisma postinstall script

### DIFF
--- a/retro-ai/package.json
+++ b/retro-ai/package.json
@@ -12,7 +12,6 @@
     "migrate:reset": "prisma migrate reset --force",
     "migrate:dev": "prisma migrate dev",
     "db:seed": "prisma db seed",
-    "postinstall": "prisma generate",
     "lint": "next lint",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Problem
Docker build is failing during the dependency installation stage with the error:
```
Error: Could not find Prisma Schema that is required for this command.
```

## Root Cause
The `postinstall` script in package.json was running `prisma generate` during `npm ci` in the `deps` stage of the Dockerfile, but the `prisma/schema.prisma` file isn't copied until later stages (`builder` and `prod-deps`).

## Solution
- **Removed** `postinstall: "prisma generate"` from package.json
- The Dockerfile already explicitly runs `npx prisma generate` in both:
  - `builder` stage (line 27) - after copying all source files including prisma/
  - `prod-deps` stage (line 55) - after copying prisma schema for production deps

## Changes
- **package.json**: Removed `postinstall` script that was causing premature Prisma generation
- No changes to Dockerfile needed - it already handles Prisma generation correctly

## Testing
- [x] Local TypeScript compilation passes
- [x] Local linting passes  
- [ ] Docker build completes successfully
- [ ] Prisma client generation works in both build stages
- [ ] Application starts correctly with database migrations

## Impact
- Fixes Docker build failure in staging deployment
- No impact on local development (Prisma client can be generated manually with `npx prisma generate`)
- Maintains all existing migration automation functionality

Related to #97 - this unblocks the automated database migration deployment.

🤖 Generated with [Claude Code](https://claude.ai/code)