### PR TITLE
Remove 'sticky' terminology from user-facing text (#124)

### DIFF
--- a/retro-ai/components/board/board-canvas.tsx
+++ b/retro-ai/components/board/board-canvas.tsx
@@ -213,7 +213,7 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
       
       // If we can't find the sticky, we need to refresh to get the latest data
       if (!movedSticky) {
-        console.log("Sticky not found locally, refreshing...");
+        console.log("Note not found locally, refreshing...");
         setTimeout(() => router.refresh(), 0);
         return;
       }
@@ -357,7 +357,7 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
     }, []),
     onStickyCreated: useCallback((data: StickyCreateEvent) => {
       // Process all sticky creations (including our own) for consistency
-      console.log("Received sticky creation event:", data);
+      console.log("Received note creation event:", data);
 
       // Create the new sticky object from the event data
       const newSticky = {
@@ -689,7 +689,7 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
       });
 
       if (!response.ok) {
-        throw new Error("Failed to update sticky note");
+        throw new Error("Failed to update note");
       }
 
       // Emit socket event after successful API call
@@ -704,8 +704,8 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
       
       // No router.refresh() needed - WebSocket handles real-time UI updates
     } catch (error) {
-      console.error("Failed to move sticky note:", error);
-      toast.error("Failed to move sticky note");
+      console.error("Failed to move note:", error);
+      toast.error("Failed to move note");
       // Revert the change
       setColumns(initialColumns);
       setUnassignedStickies(board.stickies);

--- a/retro-ai/components/board/column.tsx
+++ b/retro-ai/components/board/column.tsx
@@ -204,7 +204,7 @@ export function Column({ column, userId, boardId, isOwner, moveIndicators, onCol
         </SortableContext>
         {column.stickies.length === 0 && (
           <div className="text-center py-8 text-muted-foreground text-sm">
-            Drop sticky notes here
+            Drop notes here
           </div>
         )}
       </CardContent>

--- a/retro-ai/components/board/create-sticky-dialog.tsx
+++ b/retro-ai/components/board/create-sticky-dialog.tsx
@@ -78,7 +78,7 @@ export function CreateStickyDialog({
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.error || "Failed to create sticky note");
+        throw new Error(data.error || "Failed to create note");
       }
 
       // Emit WebSocket event for real-time updates
@@ -97,7 +97,7 @@ export function CreateStickyDialog({
         },
       });
 
-      toast.success("Sticky note created!");
+      toast.success("Note created!");
       setContent("");
       setColor(STICKY_COLORS[0].value);
       setColumnId(undefined);
@@ -114,9 +114,9 @@ export function CreateStickyDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Add Sticky Note</DialogTitle>
+          <DialogTitle>Add Note</DialogTitle>
           <DialogDescription>
-            Create a new sticky note for this board
+            Create a new note for this board
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -181,7 +181,7 @@ export function CreateStickyDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={isLoading}>
-              {isLoading ? "Creating..." : "Create Sticky"}
+              {isLoading ? "Creating..." : "Create Note"}
             </Button>
           </div>
         </form>

--- a/retro-ai/components/board/delete-sticky-dialog.tsx
+++ b/retro-ai/components/board/delete-sticky-dialog.tsx
@@ -43,7 +43,7 @@ export function DeleteStickyDialog({
 
       if (!response.ok) {
         const error = await response.json();
-        throw new Error(error.error || "Failed to delete sticky note");
+        throw new Error(error.error || "Failed to delete note");
       }
 
       // Emit WebSocket event for real-time updates
@@ -55,11 +55,11 @@ export function DeleteStickyDialog({
       // Update local state through callback
       onStickyDeleted();
 
-      toast.success("Sticky note deleted successfully");
+      toast.success("Note deleted successfully");
       onClose();
     } catch (error) {
-      console.error("Failed to delete sticky note:", error);
-      toast.error(error instanceof Error ? error.message : "Failed to delete sticky note");
+      console.error("Failed to delete note:", error);
+      toast.error(error instanceof Error ? error.message : "Failed to delete note");
     } finally {
       setIsDeleting(false);
     }
@@ -69,9 +69,9 @@ export function DeleteStickyDialog({
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Delete Sticky Note</DialogTitle>
+          <DialogTitle>Delete Note</DialogTitle>
           <DialogDescription>
-            Are you sure you want to delete this sticky note?
+            Are you sure you want to delete this note?
             <br />
             <br />
             This action cannot be undone.

--- a/retro-ai/components/board/edit-sticky-dialog.tsx
+++ b/retro-ai/components/board/edit-sticky-dialog.tsx
@@ -84,7 +84,7 @@ export function EditStickyDialog({
       const data = await response.json();
 
       if (!response.ok) {
-        throw new Error(data.error || "Failed to update sticky note");
+        throw new Error(data.error || "Failed to update note");
       }
 
       // Emit WebSocket event for real-time updates
@@ -97,7 +97,7 @@ export function EditStickyDialog({
         editors: data.sticky.editors || sticky.editors,
       });
 
-      toast.success("Sticky note updated!");
+      toast.success("Note updated!");
       onOpenChange(false);
       onStickyUpdated();
     } catch (error) {
@@ -111,9 +111,9 @@ export function EditStickyDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Edit Sticky Note</DialogTitle>
+          <DialogTitle>Edit Note</DialogTitle>
           <DialogDescription>
-            Update the content and color of your sticky note
+            Update the content and color of your note
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
@@ -161,7 +161,7 @@ export function EditStickyDialog({
               Cancel
             </Button>
             <Button type="submit" disabled={isLoading}>
-              {isLoading ? "Updating..." : "Update Sticky"}
+              {isLoading ? "Updating..." : "Update Note"}
             </Button>
           </div>
         </form>


### PR DESCRIPTION
## Summary
- Removed "sticky" terminology from all user-facing text while preserving it in code structure
- Updated dialog titles, messages, and placeholder text to use "note" instead of "sticky note"
- Maintained consistent terminology across all UI components
- Preserved all code-level naming conventions (imports, file names, APIs, socket events)

## Changes Made
**Dialog Components:**
- "Add Sticky Note" → "Add Note"
- "Edit Sticky Note" → "Edit Note" 
- "Delete Sticky Note" → "Delete Note"
- "Create Sticky" → "Create Note"
- "Update Sticky" → "Update Note"

**Messages & Feedback:**
- "Sticky note created/updated/deleted\!" → "Note created/updated/deleted\!"
- "Failed to create/update/delete sticky note" → "Failed to create/update/delete note"
- "Drop sticky notes here" → "Drop notes here"

**Console Logs:**
- Updated debug messages for consistency

## Test plan
- [x] All lint and type checks pass
- [x] No functionality regression - only text changes
- [x] Code structure and naming preserved
- [ ] Manual testing of create/edit/delete dialogs shows new terminology
- [ ] Verify no "sticky" terminology visible to users

This change improves UX by using more intuitive terminology while maintaining technical consistency.

🤖 Generated with [Claude Code](https://claude.ai/code)