### PR TITLE
Fix logout redirect to use dynamic hostname instead of localhost:3000 (#120)

### DIFF
--- a/retro-ai/components/layout/header.tsx
+++ b/retro-ai/components/layout/header.tsx
@@ -20,7 +20,8 @@ export function Header() {
   const { data: session, status } = useSession();
 
   const handleSignOut = async () => {
-    await signOut({ callbackUrl: "/" });
+    await signOut({ redirect: false });
+    window.location.href = '/';
   };
 
   return (


### PR DESCRIPTION
## Summary
- Fixed logout redirect issue where users were always redirected to `localhost:3000` in deployed environments
- Changed approach from using NextAuth's redirect to client-side navigation
- Closes #120

## Problem
NextAuth v4.24.11 has a known issue where the `signOut()` function ignores relative callback URLs and always redirects to the base URL defined in `NEXTAUTH_URL`. This caused logout to redirect to `localhost:3000` in staging/production environments even when `NEXTAUTH_URL` was correctly set in environment variables.

## Solution
- Modified `handleSignOut` in `header.tsx` to use `signOut({ redirect: false })`
- Added client-side redirect using `window.location.href = '/'`
- This bypasses NextAuth's redirect mechanism entirely

## Why This Works
1. `signOut({ redirect: false })` tells NextAuth not to handle the redirect
2. The session is still properly cleared by NextAuth
3. `window.location.href = '/'` performs a client-side redirect to the current domain
4. This ensures the redirect uses the actual hostname of the current environment

## Test Plan
- [x] Verified linting passes
- [x] Verified TypeScript type checking passes
- [ ] Test logout in development environment (should redirect to localhost:3000/)
- [ ] Test logout in staging environment (should redirect to staging URL)
- [ ] Test logout in production environment (should redirect to production URL)
- [ ] Verify session is properly cleared after logout

## Alternative Approaches Considered
1. **PR #130 approach**: Changed callback URLs to relative paths - didn't work due to NextAuth limitation
2. **Redirect callback**: Would require more complex configuration changes
3. **Router navigation**: Would add unnecessary complexity

This solution is the simplest and most reliable fix for the issue.

🤖 Generated with [Claude Code](https://claude.ai/code)