### PR TITLE
Implement consistent sticky note ordering (#80)

### DIFF
--- a/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
+++ b/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
@@ -55,7 +55,7 @@ async function getBoard(boardId: string, userId: string): Promise<BoardWithRelat
             include: {
               author: true,
             },
-            orderBy: { createdAt: "asc" },
+            orderBy: { order: "asc" },
           },
         },
       },
@@ -64,7 +64,7 @@ async function getBoard(boardId: string, userId: string): Promise<BoardWithRelat
         include: {
           author: true,
         },
-        orderBy: { createdAt: "asc" },
+        orderBy: { order: "asc" },
       },
     },
   });

--- a/retro-ai/app/api/stickies/[stickyId]/route.ts
+++ b/retro-ai/app/api/stickies/[stickyId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { calculateStickyOrder, type MoveIntent } from "@/lib/lexicographic-order";
 
 export async function PATCH(
   req: Request,
@@ -18,7 +19,17 @@ export async function PATCH(
       );
     }
 
-    const { content, color, columnId, positionX, positionY } = await req.json();
+    const { 
+      content, 
+      color, 
+      columnId, 
+      positionX, 
+      positionY,
+      // New order-related fields
+      insertAfterStickyId,
+      insertBeforeStickyId,
+      insertAtPosition
+    } = await req.json();
 
     // Find the sticky note
     const sticky = await prisma.sticky.findUnique({
@@ -58,6 +69,30 @@ export async function PATCH(
     const isEditingContent = content !== undefined || color !== undefined;
     const isNonAuthorEdit = isEditingContent && sticky.authorId !== session.user.id;
     
+    // Calculate new order if this is a move operation
+    let newOrder: number | undefined = undefined;
+    
+    if (columnId !== undefined && (insertAfterStickyId || insertBeforeStickyId || insertAtPosition)) {
+      // Get existing stickies in the target column
+      const existingStickies = await prisma.sticky.findMany({
+        where: { 
+          columnId: columnId,
+          id: { not: stickyId } // Exclude the sticky being moved
+        },
+        select: { id: true, order: true },
+        orderBy: { order: 'asc' }
+      });
+
+      const moveIntent: MoveIntent = {
+        targetColumnId: columnId,
+        ...(insertAfterStickyId && { insertAfterStickyId }),
+        ...(insertBeforeStickyId && { insertBeforeStickyId }),
+        ...(insertAtPosition && { insertAtPosition })
+      };
+
+      newOrder = calculateStickyOrder(existingStickies, moveIntent);
+    }
+    
     // Update sticky note
     const updatedSticky = await prisma.sticky.update({
       where: { id: stickyId },
@@ -67,6 +102,7 @@ export async function PATCH(
         ...(columnId !== undefined && { columnId }),
         ...(positionX !== undefined && { positionX }),
         ...(positionY !== undefined && { positionY }),
+        ...(newOrder !== undefined && { order: newOrder }),
         // Add editor to editedBy array if they're not the original author
         // and not already in the array
         ...(isNonAuthorEdit && !sticky.editedBy.includes(session.user.id) && {

--- a/retro-ai/app/api/stickies/[stickyId]/route.ts
+++ b/retro-ai/app/api/stickies/[stickyId]/route.ts
@@ -19,6 +19,7 @@ export async function PATCH(
       );
     }
 
+    const requestBody = await req.json();
     const { 
       content, 
       color, 
@@ -29,7 +30,18 @@ export async function PATCH(
       insertAfterStickyId,
       insertBeforeStickyId,
       insertAtPosition
-    } = await req.json();
+    } = requestBody;
+
+    // Debug logging for move intent
+    if (columnId !== undefined) {
+      console.log(`[STICKY-MOVE] ${stickyId} -> Column: ${columnId || 'unassigned'}`);
+      console.log(`[STICKY-MOVE] Move intent:`, {
+        insertAfterStickyId,
+        insertBeforeStickyId,
+        insertAtPosition
+      });
+      console.log(`[STICKY-MOVE] Full request body:`, requestBody);
+    }
 
     // Find the sticky note
     const sticky = await prisma.sticky.findUnique({
@@ -90,7 +102,12 @@ export async function PATCH(
         ...(insertAtPosition && { insertAtPosition })
       };
 
+      console.log(`[STICKY-MOVE] Existing stickies in column:`, existingStickies.length);
+      console.log(`[STICKY-MOVE] Calculated move intent:`, moveIntent);
+
       newOrder = calculateStickyOrder(existingStickies, moveIntent);
+      
+      console.log(`[STICKY-MOVE] Calculated new order:`, newOrder);
     }
     
     // Update sticky note

--- a/retro-ai/app/api/stickies/[stickyId]/route.ts
+++ b/retro-ai/app/api/stickies/[stickyId]/route.ts
@@ -32,16 +32,6 @@ export async function PATCH(
       insertAtPosition
     } = requestBody;
 
-    // Debug logging for move intent
-    if (columnId !== undefined) {
-      console.log(`[STICKY-MOVE] ${stickyId} -> Column: ${columnId || 'unassigned'}`);
-      console.log(`[STICKY-MOVE] Move intent:`, {
-        insertAfterStickyId,
-        insertBeforeStickyId,
-        insertAtPosition
-      });
-      console.log(`[STICKY-MOVE] Full request body:`, requestBody);
-    }
 
     // Find the sticky note
     const sticky = await prisma.sticky.findUnique({
@@ -102,12 +92,7 @@ export async function PATCH(
         ...(insertAtPosition && { insertAtPosition })
       };
 
-      console.log(`[STICKY-MOVE] Existing stickies in column:`, existingStickies.length);
-      console.log(`[STICKY-MOVE] Calculated move intent:`, moveIntent);
-
       newOrder = calculateStickyOrder(existingStickies, moveIntent);
-      
-      console.log(`[STICKY-MOVE] Calculated new order:`, newOrder);
     }
     
     // Update sticky note

--- a/retro-ai/components/board/board-canvas.tsx
+++ b/retro-ai/components/board/board-canvas.tsx
@@ -184,17 +184,13 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
     onStickyMoved: useCallback((data: MovementEvent) => {
       // Only update if this movement wasn't initiated by us
       if (isLocalMovement.current || data.userId === userId) {
-        console.log(`[MULTI-USER] Skipping movement for ${data.stickyId} - local movement or same user`);
         return;
       }
 
       // Skip if already animating this sticky to prevent conflicts
       if (flipAnimation.isAnimating(data.stickyId)) {
-        console.log(`[MULTI-USER] Skipping animation for ${data.stickyId} - already in progress`);
         return;
       }
-
-      console.log(`[MULTI-USER] Processing remote movement from ${data.userName}:`, data);
 
       // Set move indicator for this sticky
       if (data.userName) {
@@ -225,16 +221,12 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
               if (data.order !== undefined) {
                 stickyToReorder.order = data.order;
               }
-              console.log(`[MULTI-USER] Reordering sticky ${data.stickyId} within unassigned area`);
-              
               // Remove from current position and add with new order
               const filtered = prevUnassigned.filter(s => s.id !== data.stickyId);
               const result = [...filtered, stickyToReorder];
               
               // Sort by order to maintain consistent positioning
               result.sort((a, b) => a.order - b.order);
-              
-              console.log(`[MULTI-USER] Updated unassigned area with sticky ${data.stickyId} at order ${stickyToReorder.order}`);
               return result;
             } else {
               // Sticky is not in unassigned, so it must be coming from a column
@@ -256,8 +248,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                 if (data.order !== undefined) {
                   stickyFromColumn.order = data.order;
                 }
-                console.log(`[MULTI-USER] Found sticky ${data.stickyId} in column ${column.id}, moving to unassigned`);
-                
                 // Add to unassigned area immediately
                 setUnassignedStickies(prevUnassigned => {
                   // Double-check it's not already there
@@ -268,7 +258,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                   const result = [...prevUnassigned, stickyFromColumn!];
                   result.sort((a, b) => a.order - b.order);
                   
-                  console.log(`[MULTI-USER] Added sticky ${data.stickyId} to unassigned with order ${stickyFromColumn!.order}`);
                   return result;
                 });
                 
@@ -295,8 +284,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
               if (data.order !== undefined) {
                 stickyFromUnassigned.order = data.order;
               }
-              console.log(`[MULTI-USER] Found sticky ${data.stickyId} in unassigned area, moving to column ${data.columnId}`);
-              
               // Add to target column immediately
               setColumns(prevColumns => {
                 return prevColumns.map(column => {
@@ -311,8 +298,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                     
                     // Sort by order
                     newStickies.sort((a, b) => a.order - b.order);
-                    
-                    console.log(`[MULTI-USER] Added sticky ${data.stickyId} to column ${data.columnId} with order ${stickyFromUnassigned.order}`);
                     
                     return {
                       ...column,
@@ -344,7 +329,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                 if (data.order !== undefined) {
                   stickyFromColumn.order = data.order;
                 }
-                console.log(`[MULTI-USER] Found sticky ${data.stickyId} in column ${column.id}, moving to column ${data.columnId}`);
                 // Remove from source column
                 return {
                   ...column,
@@ -369,8 +353,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                 // Sort by order
                 newStickies.sort((a, b) => a.order - b.order);
                 
-                console.log(`[MULTI-USER] Added sticky ${data.stickyId} to column ${data.columnId} with order ${stickyFromColumn.order}`);
-                
                 return {
                   ...column,
                   stickies: newStickies,
@@ -388,7 +370,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
         return;
       }
 
-      console.log("Received column rename event:", data);
 
       // Update the column title in local state
       setColumns(prevColumns =>
@@ -405,7 +386,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
         return;
       }
 
-      console.log("Received column delete event:", data);
 
       // For remote users, we need to move the stickies to unassigned and remove the column
       setColumns(prevColumns => {
@@ -462,7 +442,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
     }, []),
     onStickyCreated: useCallback((data: StickyCreateEvent) => {
       // Process all sticky creations (including our own) for consistency
-      console.log("Received note creation event:", data);
 
       // Create the new sticky object from the event data
       const newSticky = {
@@ -819,12 +798,10 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
           // AFTER the active item is removed. Since activeIndex < overIndex, removing activeIndex
           // shifts everything after it down by 1, so the item we want is currently at overIndex
           insertAfterIndex = overIndex;
-          console.log(`[LOCAL-USER] Moving down: activeIndex=${activeIndex}, overIndex=${overIndex}, insertAfterIndex=${insertAfterIndex}`);
         } else {
           // Moving up: insert after the item that's currently at overIndex-1
           // (since we remove activeIndex which is after overIndex, overIndex-1 stays in place)
           insertAfterIndex = overIndex - 1;
-          console.log(`[LOCAL-USER] Moving up: activeIndex=${activeIndex}, overIndex=${overIndex}, insertAfterIndex=${insertAfterIndex}`);
         }
         
         if (insertAfterIndex >= 0 && insertAfterIndex < originalOverItems.length) {
@@ -832,21 +809,17 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
           // Make sure we're not trying to insert after ourselves
           if (targetSticky.id !== activeId) {
             moveIntent.insertAfterStickyId = targetSticky.id;
-            console.log(`[LOCAL-USER] Moving ${activeId}: insert after ${targetSticky.id} (index ${insertAfterIndex})`);
           } else {
             // If we're trying to insert after ourselves, we need to adjust
             if (insertAfterIndex > 0) {
               const alternativeSticky = originalOverItems[insertAfterIndex - 1];
               moveIntent.insertAfterStickyId = alternativeSticky.id;
-              console.log(`[LOCAL-USER] Moving ${activeId}: adjusted to insert after ${alternativeSticky.id}`);
             } else {
               moveIntent.insertAtPosition = 'start';
-              console.log(`[LOCAL-USER] Moving ${activeId}: adjusted to start position`);
             }
           }
         } else {
           moveIntent.insertAtPosition = insertAfterIndex < 0 ? 'start' : 'end';
-          console.log(`[LOCAL-USER] Moving ${activeId}: using position ${moveIntent.insertAtPosition}`);
         }
       }
     } else {
@@ -883,8 +856,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
       // Mark this as a local movement to prevent echo
       isLocalMovement.current = true;
       
-      console.log(`[LOCAL-USER] Sending move intent for ${activeId}:`, moveIntent);
-      
       const response = await fetch(`/api/stickies/${activeId}`, {
         method: "PATCH",
         headers: {
@@ -900,8 +871,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
       const result = await response.json();
       const calculatedOrder = result.sticky.order;
 
-      console.log(`[LOCAL-USER] Server calculated order ${calculatedOrder} for sticky ${activeId}`);
-
       // Update local state with server-calculated order
       if (targetColumnId === null) {
         // Update unassigned stickies with correct order
@@ -912,7 +881,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
               : sticky
           ).sort((a, b) => a.order - b.order)
         );
-        console.log(`[LOCAL-USER] Updated local unassigned sticky ${activeId} with order ${calculatedOrder}`);
       } else {
         // Update column stickies with correct order
         setColumns(prevColumns => 
@@ -929,7 +897,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
               : column
           )
         );
-        console.log(`[LOCAL-USER] Updated local column sticky ${activeId} with order ${calculatedOrder}`);
       }
 
       // Emit socket event with server-calculated order
@@ -940,7 +907,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
           order: calculatedOrder,
           boardId: board.id,
         });
-        console.log(`[LOCAL-USER] Emitted movement event to other users:`, { stickyId: activeId, columnId: targetColumnId, order: calculatedOrder, boardId: board.id });
       }
       
       // No router.refresh() needed - WebSocket handles real-time UI updates
@@ -953,7 +919,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
     } finally {
       // Reset the local movement flag after a short delay
       setTimeout(() => {
-        console.log(`[LOCAL-USER] Resetting local movement flag for ${activeId}`);
         isLocalMovement.current = false;
       }, 100);
     }

--- a/retro-ai/components/board/board-canvas.tsx
+++ b/retro-ai/components/board/board-canvas.tsx
@@ -842,6 +842,36 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
 
       console.log(`[LOCAL-USER] Server calculated order ${calculatedOrder} for sticky ${activeId}`);
 
+      // Update local state with server-calculated order
+      if (targetColumnId === null) {
+        // Update unassigned stickies with correct order
+        setUnassignedStickies(prev => 
+          prev.map(sticky => 
+            sticky.id === activeId 
+              ? { ...sticky, order: calculatedOrder }
+              : sticky
+          ).sort((a, b) => a.order - b.order)
+        );
+        console.log(`[LOCAL-USER] Updated local unassigned sticky ${activeId} with order ${calculatedOrder}`);
+      } else {
+        // Update column stickies with correct order
+        setColumns(prevColumns => 
+          prevColumns.map(column => 
+            column.id === targetColumnId
+              ? {
+                  ...column,
+                  stickies: column.stickies.map(sticky =>
+                    sticky.id === activeId
+                      ? { ...sticky, order: calculatedOrder }
+                      : sticky
+                  ).sort((a, b) => a.order - b.order)
+                }
+              : column
+          )
+        );
+        console.log(`[LOCAL-USER] Updated local column sticky ${activeId} with order ${calculatedOrder}`);
+      }
+
       // Emit socket event with server-calculated order
       if (isConnected) {
         emitStickyMoved({

--- a/retro-ai/hooks/use-socket.ts
+++ b/retro-ai/hooks/use-socket.ts
@@ -8,6 +8,7 @@ interface MovementEvent {
   columnId: string | null;
   positionX?: number;
   positionY?: number;
+  order?: number;
   boardId?: string;
   userId: string;
   timestamp: number;

--- a/retro-ai/lib/lexicographic-order.test.ts
+++ b/retro-ai/lib/lexicographic-order.test.ts
@@ -1,0 +1,193 @@
+import {
+  calculateStickyOrder,
+  needsRebalancing,
+  rebalanceOrders,
+  generateInitialOrders,
+  type StickyOrderInfo
+} from './lexicographic-order';
+
+describe('Lexicographic Order Utilities', () => {
+  const createSticky = (id: string, order: number): StickyOrderInfo => ({ id, order });
+
+  describe('calculateStickyOrder', () => {
+    it('should return 1000 for empty column', () => {
+      const result = calculateStickyOrder([], { targetColumnId: 'col1' });
+      expect(result).toBe(1000.0);
+    });
+
+    it('should insert at the beginning when insertAtPosition is start', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAtPosition: 'start' 
+      });
+      expect(result).toBe(500.0); // 1000 / 2
+    });
+
+    it('should insert at the end when insertAtPosition is end', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAtPosition: 'end' 
+      });
+      expect(result).toBe(3000.0); // 2000 + 1000
+    });
+
+    it('should insert after specific sticky in middle', () => {
+      const stickies = [
+        createSticky('1', 1000), 
+        createSticky('2', 2000), 
+        createSticky('3', 3000)
+      ];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAfterStickyId: '2' 
+      });
+      expect(result).toBe(2500.0); // (2000 + 3000) / 2
+    });
+
+    it('should insert after last sticky', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAfterStickyId: '2' 
+      });
+      expect(result).toBe(3000.0); // 2000 + 1000
+    });
+
+    it('should insert before specific sticky in middle', () => {
+      const stickies = [
+        createSticky('1', 1000), 
+        createSticky('2', 2000), 
+        createSticky('3', 3000)
+      ];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertBeforeStickyId: '2' 
+      });
+      expect(result).toBe(1500.0); // (1000 + 2000) / 2
+    });
+
+    it('should insert before first sticky', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertBeforeStickyId: '1' 
+      });
+      expect(result).toBe(500.0); // 1000 / 2
+    });
+
+    it('should throw error when insertAfterStickyId not found', () => {
+      const stickies = [createSticky('1', 1000)];
+      expect(() => {
+        calculateStickyOrder(stickies, { 
+          targetColumnId: 'col1', 
+          insertAfterStickyId: 'nonexistent' 
+        });
+      }).toThrow('Sticky with id nonexistent not found in target column');
+    });
+
+    it('should throw error when insertBeforeStickyId not found', () => {
+      const stickies = [createSticky('1', 1000)];
+      expect(() => {
+        calculateStickyOrder(stickies, { 
+          targetColumnId: 'col1', 
+          insertBeforeStickyId: 'nonexistent' 
+        });
+      }).toThrow('Sticky with id nonexistent not found in target column');
+    });
+
+    it('should handle unsorted input by sorting first', () => {
+      const stickies = [
+        createSticky('2', 2000), 
+        createSticky('1', 1000), 
+        createSticky('3', 3000)
+      ];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAfterStickyId: '1' 
+      });
+      expect(result).toBe(1500.0); // Should insert between 1000 and 2000
+    });
+  });
+
+  describe('needsRebalancing', () => {
+    it('should return false for empty array', () => {
+      expect(needsRebalancing([])).toBe(false);
+    });
+
+    it('should return false for single item', () => {
+      expect(needsRebalancing([createSticky('1', 1000)])).toBe(false);
+    });
+
+    it('should return false when gaps are sufficient', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      expect(needsRebalancing(stickies)).toBe(false);
+    });
+
+    it('should return true when gaps are too small', () => {
+      const stickies = [
+        createSticky('1', 1000), 
+        createSticky('2', 1000.0000001) // Very small gap
+      ];
+      expect(needsRebalancing(stickies)).toBe(true);
+    });
+  });
+
+  describe('rebalanceOrders', () => {
+    it('should return empty array for empty input', () => {
+      expect(rebalanceOrders([])).toEqual([]);
+    });
+
+    it('should rebalance orders evenly', () => {
+      const stickies = [
+        createSticky('1', 1000.1), 
+        createSticky('2', 1000.2), 
+        createSticky('3', 1000.3)
+      ];
+      const result = rebalanceOrders(stickies);
+      
+      expect(result).toEqual([
+        { id: '1', order: 1000.0 },
+        { id: '2', order: 2000.0 },
+        { id: '3', order: 3000.0 }
+      ]);
+    });
+
+    it('should maintain original order when rebalancing', () => {
+      const stickies = [
+        createSticky('3', 3000), 
+        createSticky('1', 1000), 
+        createSticky('2', 2000)
+      ];
+      const result = rebalanceOrders(stickies);
+      
+      // Should be sorted by order, not by input order
+      expect(result[0].id).toBe('1');
+      expect(result[1].id).toBe('2'); 
+      expect(result[2].id).toBe('3');
+    });
+  });
+
+  describe('generateInitialOrders', () => {
+    it('should generate correct number of orders', () => {
+      const orders = generateInitialOrders(3);
+      expect(orders).toHaveLength(3);
+    });
+
+    it('should generate orders with default values', () => {
+      const orders = generateInitialOrders(3);
+      expect(orders).toEqual([1000.0, 2000.0, 3000.0]);
+    });
+
+    it('should generate orders with custom start and increment', () => {
+      const orders = generateInitialOrders(2, 500.0, 250.0);
+      expect(orders).toEqual([500.0, 750.0]);
+    });
+
+    it('should return empty array for zero count', () => {
+      const orders = generateInitialOrders(0);
+      expect(orders).toEqual([]);
+    });
+  });
+});

--- a/retro-ai/lib/lexicographic-order.ts
+++ b/retro-ai/lib/lexicographic-order.ts
@@ -1,0 +1,153 @@
+/**
+ * Lexicographic ordering utility for sticky notes within columns
+ * 
+ * This utility provides functions to calculate order values for sticky notes
+ * when they are moved within columns. It uses floating-point arithmetic to
+ * enable insertion between any two positions without requiring renumbering
+ * of existing items.
+ */
+
+export interface StickyOrderInfo {
+  id: string;
+  order: number;
+}
+
+export interface MoveIntent {
+  targetColumnId: string | null;
+  insertAfterStickyId?: string;
+  insertBeforeStickyId?: string;
+  insertAtPosition?: 'start' | 'end';
+}
+
+/**
+ * Calculate the order value for a sticky note based on its target position
+ * @param existingStickies Array of existing stickies in the target column, ordered by their order field
+ * @param moveIntent Description of where to insert the sticky
+ * @returns The calculated order value
+ */
+export function calculateStickyOrder(
+  existingStickies: StickyOrderInfo[],
+  moveIntent: MoveIntent
+): number {
+  // Sort existing stickies by order to ensure proper positioning
+  const sortedStickies = [...existingStickies].sort((a, b) => a.order - b.order);
+  
+  // Handle empty column
+  if (sortedStickies.length === 0) {
+    return 1000.0; // Start with a reasonable base value
+  }
+
+  // Handle insertion at the start
+  if (moveIntent.insertAtPosition === 'start' || moveIntent.insertBeforeStickyId === sortedStickies[0].id) {
+    const firstOrder = sortedStickies[0].order;
+    return firstOrder / 2.0; // Insert before first item
+  }
+
+  // Handle insertion at the end
+  if (moveIntent.insertAtPosition === 'end' || moveIntent.insertAfterStickyId === sortedStickies[sortedStickies.length - 1].id) {
+    const lastOrder = sortedStickies[sortedStickies.length - 1].order;
+    return lastOrder + 1000.0; // Insert after last item
+  }
+
+  // Handle insertion after a specific sticky
+  if (moveIntent.insertAfterStickyId) {
+    const targetIndex = sortedStickies.findIndex(s => s.id === moveIntent.insertAfterStickyId);
+    
+    if (targetIndex === -1) {
+      throw new Error(`Sticky with id ${moveIntent.insertAfterStickyId} not found in target column`);
+    }
+
+    const currentOrder = sortedStickies[targetIndex].order;
+    
+    // If this is the last item, add to the end
+    if (targetIndex === sortedStickies.length - 1) {
+      return currentOrder + 1000.0;
+    }
+    
+    // Insert between current and next item
+    const nextOrder = sortedStickies[targetIndex + 1].order;
+    return (currentOrder + nextOrder) / 2.0;
+  }
+
+  // Handle insertion before a specific sticky
+  if (moveIntent.insertBeforeStickyId) {
+    const targetIndex = sortedStickies.findIndex(s => s.id === moveIntent.insertBeforeStickyId);
+    
+    if (targetIndex === -1) {
+      throw new Error(`Sticky with id ${moveIntent.insertBeforeStickyId} not found in target column`);
+    }
+
+    const currentOrder = sortedStickies[targetIndex].order;
+    
+    // If this is the first item, insert before it
+    if (targetIndex === 0) {
+      return currentOrder / 2.0;
+    }
+    
+    // Insert between previous and current item
+    const prevOrder = sortedStickies[targetIndex - 1].order;
+    return (prevOrder + currentOrder) / 2.0;
+  }
+
+  // Default: append to end
+  const lastOrder = sortedStickies[sortedStickies.length - 1].order;
+  return lastOrder + 1000.0;
+}
+
+/**
+ * Check if the order values in a column need rebalancing
+ * This happens when the precision becomes too small for reliable insertion
+ * @param stickies Array of stickies in the column
+ * @returns true if rebalancing is needed
+ */
+export function needsRebalancing(stickies: StickyOrderInfo[]): boolean {
+  if (stickies.length < 2) return false;
+  
+  const sortedStickies = [...stickies].sort((a, b) => a.order - b.order);
+  
+  // Check for minimum gap between consecutive items
+  const minimumGap = 0.000001; // 1e-6
+  
+  for (let i = 0; i < sortedStickies.length - 1; i++) {
+    const gap = sortedStickies[i + 1].order - sortedStickies[i].order;
+    if (gap < minimumGap) {
+      return true;
+    }
+  }
+  
+  return false;
+}
+
+/**
+ * Rebalance order values for stickies in a column
+ * This spreads them out evenly to allow for future insertions
+ * @param stickies Array of stickies to rebalance
+ * @returns Array of updated stickies with new order values
+ */
+export function rebalanceOrders(stickies: StickyOrderInfo[]): StickyOrderInfo[] {
+  if (stickies.length === 0) return [];
+  
+  const sortedStickies = [...stickies].sort((a, b) => a.order - b.order);
+  const baseOrder = 1000.0;
+  const increment = 1000.0;
+  
+  return sortedStickies.map((sticky, index) => ({
+    ...sticky,
+    order: baseOrder + (index * increment)
+  }));
+}
+
+/**
+ * Generate initial order values for a batch of new stickies
+ * @param count Number of stickies to generate orders for
+ * @param startOrder Starting order value (default: 1000.0)
+ * @param increment Increment between orders (default: 1000.0)
+ * @returns Array of order values
+ */
+export function generateInitialOrders(
+  count: number, 
+  startOrder: number = 1000.0, 
+  increment: number = 1000.0
+): number[] {
+  return Array.from({ length: count }, (_, index) => startOrder + (index * increment));
+}

--- a/retro-ai/lib/socket-context.tsx
+++ b/retro-ai/lib/socket-context.tsx
@@ -9,6 +9,7 @@ interface MovementEvent {
   columnId: string | null;
   positionX?: number;
   positionY?: number;
+  order?: number;
   boardId?: string;
   userId: string;
   timestamp: number;

--- a/retro-ai/prisma/migrations/20250726182603_add_sticky_order_field/migration.sql
+++ b/retro-ai/prisma/migrations/20250726182603_add_sticky_order_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Sticky" ADD COLUMN     "order" DOUBLE PRECISION NOT NULL DEFAULT 0.0;

--- a/retro-ai/prisma/schema.prisma
+++ b/retro-ai/prisma/schema.prisma
@@ -94,6 +94,7 @@ model Sticky {
   column    Column?  @relation(fields: [columnId], references: [id])
   positionX Float
   positionY Float
+  order     Float    @default(0.0)
   authorId  String
   author    User     @relation(fields: [authorId], references: [id])
   editedBy  String[] @default([])

--- a/retro-ai/scripts/fix-order-values.ts
+++ b/retro-ai/scripts/fix-order-values.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env tsx
+
+/**
+ * Data Migration Script: Fix Order Values for Existing Sticky Notes
+ * 
+ * This script assigns proper order values to all existing sticky notes
+ * that currently have order = 0.0 after the schema migration.
+ * 
+ * Strategy:
+ * 1. Group stickies by column (including unassigned)
+ * 2. Order them by createdAt timestamp within each group
+ * 3. Assign order values like 1000.0, 2000.0, 3000.0 etc.
+ * 
+ * Usage: npx tsx scripts/fix-order-values.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function fixStickyOrderValues() {
+  console.log('🔄 Starting sticky note order value migration...');
+  
+  try {
+    // Get all stickies grouped by board and column
+    const boards = await prisma.board.findMany({
+      include: {
+        stickies: {
+          orderBy: { createdAt: 'asc' },
+          include: {
+            column: true
+          }
+        }
+      }
+    });
+
+    let totalUpdated = 0;
+
+    for (const board of boards) {
+      console.log(`📋 Processing board: ${board.title} (${board.stickies.length} stickies)`);
+      
+      // Group stickies by columnId (null for unassigned)
+      const stickyGroups = new Map<string | null, typeof board.stickies>();
+      
+      for (const sticky of board.stickies) {
+        const columnId = sticky.columnId;
+        if (!stickyGroups.has(columnId)) {
+          stickyGroups.set(columnId, []);
+        }
+        stickyGroups.get(columnId)!.push(sticky);
+      }
+
+      // Process each group
+      for (const [columnId, stickies] of stickyGroups) {
+        const columnName = columnId ? stickies[0]?.column?.title || 'Unknown Column' : 'Unassigned';
+        console.log(`  📝 Processing ${columnName}: ${stickies.length} stickies`);
+        
+        // Sort by createdAt to maintain chronological order
+        stickies.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+        
+        // Update each sticky with proper order values
+        for (let i = 0; i < stickies.length; i++) {
+          const sticky = stickies[i];
+          const newOrder = 1000.0 + (i * 1000.0); // 1000, 2000, 3000, etc.
+          
+          await prisma.sticky.update({
+            where: { id: sticky.id },
+            data: { order: newOrder }
+          });
+          
+          console.log(`    ✅ Updated sticky "${sticky.content.substring(0, 30)}..." order: ${newOrder}`);
+          totalUpdated++;
+        }
+      }
+    }
+
+    // Verify the updates
+    const verification = await prisma.sticky.groupBy({
+      by: ['order'],
+      _count: true,
+      orderBy: { order: 'asc' }
+    });
+
+    console.log('\n📊 Order value distribution after migration:');
+    for (const group of verification) {
+      console.log(`  Order ${group.order}: ${group._count} stickies`);
+    }
+
+    console.log(`\n✅ Migration completed successfully!`);
+    console.log(`📈 Total stickies updated: ${totalUpdated}`);
+    
+    // Check for any remaining zero-order stickies
+    const zeroOrderCount = await prisma.sticky.count({
+      where: { order: 0.0 }
+    });
+    
+    if (zeroOrderCount > 0) {
+      console.log(`⚠️  Warning: ${zeroOrderCount} stickies still have order = 0.0`);
+    } else {
+      console.log(`🎉 All stickies now have proper order values!`);
+    }
+
+  } catch (error) {
+    console.error('❌ Migration failed:', error);
+    throw error;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Run the migration
+if (require.main === module) {
+  fixStickyOrderValues()
+    .then(() => {
+      console.log('Migration script completed.');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('Migration script failed:', error);
+      process.exit(1);
+    });
+}
+
+export { fixStickyOrderValues };


### PR DESCRIPTION
## Summary
- Implements server-authoritative sticky note ordering for consistent positioning across all users
- Uses lexicographic ordering (float values) to enable insertion between any two items without renumbering
- Frontend sends move intent, server calculates order values and broadcasts to all clients

## Technical Implementation

### Database Changes
- Added `order Float @default(0.0)` field to Sticky model
- Created migration to add order field with default values
- Updated queries to order stickies by order field within columns

### Server-Side Order Calculation
- Created `lib/lexicographic-order.ts` utility with comprehensive test suite
- Enhanced sticky PATCH API to accept move intent (`insertAfterStickyId`, `insertBeforeStickyId`, `insertAtPosition`)
- Server calculates new order values using fractional positioning (e.g., between 1.0 and 2.0 = 1.5)

### Real-time Communication
- Updated socket events to include server-calculated order values
- Enhanced board-canvas.tsx to send move descriptions instead of calculated positions
- All clients receive same order value from server for consistency

### Key Benefits
- **Consistency**: Server is single source of truth for ordering decisions
- **Conflict Resolution**: No race conditions when multiple users reorder simultaneously
- **Performance**: Insertion between items without renumbering existing records
- **Real-time Sync**: All users see same order immediately via WebSocket events

## Test plan
- [x] Unit tests for lexicographic ordering utility (21 tests passing)
- [x] TypeScript type checking passes
- [x] ESLint code quality checks pass
- [x] Server-side order calculation with fractional positioning
- [x] Socket event broadcasting includes order field
- [x] Database migration applied successfully

## Files Modified
- `prisma/schema.prisma` - Added order field to Sticky model
- `lib/lexicographic-order.ts` - New ordering utility (with tests)
- `app/api/stickies/[stickyId]/route.ts` - Server-side order calculation
- `components/board/board-canvas.tsx` - Move intent instead of order calculation
- `app/(dashboard)/boards/[boardId]/page.tsx` - Query ordering by order field
- `hooks/use-socket.ts` & `lib/socket-context.tsx` - Order field in socket events
- `server.js` - Enhanced socket events (already supported via spread operator)
- `SOCKET-SERVER.md` - Updated documentation

Fixes #80

🤖 Generated with [Claude Code](https://claude.ai/code)