### PR TITLE
Fix avatar size on sticky notes to prevent clipping (#150)

### DIFF
--- a/retro-ai/components/board/sticky-note.tsx
+++ b/retro-ai/components/board/sticky-note.tsx
@@ -156,8 +156,8 @@ export function StickyNote({ sticky, userId, moveIndicator: propMoveIndicator }:
                 <span className="text-xs text-muted-foreground">
                   {sticky.author.name || sticky.author.email}
                 </span>
-                <Avatar className="h-5 w-5">
-                  <AvatarFallback className="text-xs">
+                <Avatar className="h-7 w-7">
+                  <AvatarFallback className="text-sm">
                     {getInitials(sticky.author.name || '') || 
                      getInitials(sticky.author.email) || "U"}
                   </AvatarFallback>
@@ -180,8 +180,8 @@ export function StickyNote({ sticky, userId, moveIndicator: propMoveIndicator }:
                   <span className="text-xs text-muted-foreground">Edited by</span>
                   <div className="flex items-center gap-1">
                     {sticky.editors!.map((editor) => (
-                      <Avatar key={editor.id} className="h-5 w-5">
-                        <AvatarFallback className="text-xs">
+                      <Avatar key={editor.id} className="h-7 w-7">
+                        <AvatarFallback className="text-sm">
                           {getInitials(editor.name || '') || 
                            getInitials(editor.email) || "U"}
                         </AvatarFallback>


### PR DESCRIPTION
## Summary
- Increased avatar size from 20x20 pixels to 28x28 pixels to prevent clipping of user initials
- Updated font size for initials to match the larger avatar size
- Applied changes to both author and editor avatars on sticky notes

## Changes Made
- Changed avatar classes from `h-5 w-5` to `h-7 w-7` in sticky-note.tsx
- Updated text size from `text-xs` to `text-sm` for better readability

## Test Plan
- [x] Verified avatars display properly without clipping initials
- [x] Tested with different user names and initial combinations
- [x] Ensured responsive layout still works
- [x] Ran `npm run lint` - no errors
- [x] Ran `npm run typecheck` - no errors

Closes #150

🤖 Generated with [Claude Code](https://claude.ai/code)