### PR TITLE
Remove Recent Activity section from dashboard (#151)

### DIFF
--- a/retro-ai/app/(dashboard)/dashboard/page.tsx
+++ b/retro-ai/app/(dashboard)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Plus, Users, Presentation, Clock } from "lucide-react";
+import { Plus, Users, Presentation } from "lucide-react";
 
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
@@ -48,19 +48,6 @@ export default async function DashboardPage() {
             <div className="text-2xl font-bold">0</div>
             <p className="text-xs text-muted-foreground">
               Join or create a team
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Recent Activity</CardTitle>
-            <Clock className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">-</div>
-            <p className="text-xs text-muted-foreground">
-              No recent activity
             </p>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- Removed the "Recent Activity" section from the dashboard home screen
- Cleaned up related code and imports
- Improved dashboard layout by removing unnecessary UI element

## Changes Made
- **Removed**: "Recent Activity" card from dashboard page (lines 55-66)
- **Removed**: Unused `Clock` import from lucide-react
- **Result**: Dashboard now displays 3 cards instead of 4 in the top grid

## Layout Impact
- Grid layout remains responsive using existing `md:grid-cols-2 lg:grid-cols-4` classes
- Cards now distribute nicely: Total Boards, Teams, Quick Actions
- No impact on bottom section (Recent Boards, Your Teams)
- Better utilization of screen space

## Code Quality
- [x] Removed all references to Recent Activity
- [x] Cleaned up unused imports
- [x] No broken references remain
- [x] Layout remains responsive on all screen sizes
- [x] Ran `npm run lint` - no errors
- [x] Ran `npm run typecheck` - no errors

## Before & After
**Before**: 4 cards in top grid (Total Boards, Teams, Recent Activity, Quick Actions)
**After**: 3 cards in top grid (Total Boards, Teams, Quick Actions)

This enhancement removes an unused UI element that was taking up valuable screen real estate without providing user value.

Closes #151

🤖 Generated with [Claude Code](https://claude.ai/code)