### PR TITLE
Deploy to staging: Multiple UI improvements and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,25 @@ npx prisma migrate dev # Run migrations
 npx prisma db seed    # Seed database
 ```
 
+### Test Accounts (Development/Staging Only)
+
+The following test accounts are automatically created when seeding the database:
+
+| Email | Password | Team Memberships |
+|-------|----------|------------------|
+| TestUser1@example.com | password | Alpha Team |
+| TestUser2@example.com | password | Alpha Team, Gamma Team |
+| TestUser3@example.com | password | Alpha Team, Gamma Team |
+| TestUser4@example.com | password | Alpha Team, Gamma Team |
+| TestUser5@example.com | password | Alpha Team |
+| TestUser6@example.com | password | Beta Team |
+| TestUser7@example.com | password | Beta Team, Gamma Team |
+| TestUser8@example.com | password | Beta Team |
+| TestUser9@example.com | password | Beta Team, Gamma Team |
+| TestUser10@example.com | password | Beta Team |
+
+**Note**: These accounts are only created in development and staging environments. Each team has a pre-populated retrospective board using the 4Ls template with sample sticky notes.
+
 ### Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -182,18 +182,18 @@ npx prisma db seed    # Seed database
 
 The following test accounts are automatically created when seeding the database:
 
-| Email | Password | Team Memberships |
-|-------|----------|------------------|
-| TestUser1@example.com | password | Alpha Team |
-| TestUser2@example.com | password | Alpha Team, Gamma Team |
-| TestUser3@example.com | password | Alpha Team, Gamma Team |
-| TestUser4@example.com | password | Alpha Team, Gamma Team |
-| TestUser5@example.com | password | Alpha Team |
-| TestUser6@example.com | password | Beta Team |
-| TestUser7@example.com | password | Beta Team, Gamma Team |
-| TestUser8@example.com | password | Beta Team |
-| TestUser9@example.com | password | Beta Team, Gamma Team |
-| TestUser10@example.com | password | Beta Team |
+| Email | Password | Team Memberships | Team Owner Of |
+|-------|----------|------------------|---------------|
+| TestUser1@example.com | password | Alpha Team | Alpha Team |
+| TestUser2@example.com | password | Alpha Team, Gamma Team | Gamma Team |
+| TestUser3@example.com | password | Alpha Team, Gamma Team | - |
+| TestUser4@example.com | password | Alpha Team, Gamma Team | - |
+| TestUser5@example.com | password | Alpha Team | - |
+| TestUser6@example.com | password | Beta Team | Beta Team |
+| TestUser7@example.com | password | Beta Team, Gamma Team | - |
+| TestUser8@example.com | password | Beta Team | - |
+| TestUser9@example.com | password | Beta Team, Gamma Team | - |
+| TestUser10@example.com | password | Beta Team | - |
 
 **Note**: These accounts are only created in development and staging environments. Each team has a pre-populated retrospective board using the 4Ls template with sample sticky notes.
 

--- a/retro-ai/__tests__/column-creation-restrictions.integration.test.tsx
+++ b/retro-ai/__tests__/column-creation-restrictions.integration.test.tsx
@@ -245,9 +245,9 @@ describe('Column Creation Restrictions - Integration Tests', () => {
       // - Unassigned area
       expect(screen.getByTestId('unassigned-area')).toBeInTheDocument();
       
-      // - Floating add note button (should exist but we don't test specific implementation)
-      const allButtons = screen.getAllByRole('button');
-      expect(allButtons.length).toBeGreaterThan(0); // Should have some buttons
+      // Note: Create note button has been moved to header (Issue #156)
+      // BoardCanvas no longer contains the floating add note button
+      // Non-owners can still interact with all board content
     });
   });
 
@@ -263,7 +263,6 @@ describe('Column Creation Restrictions - Integration Tests', () => {
       );
 
       // Get initial layout with Add Column button
-      const initialButtons = screen.getAllByRole('button');
       const hasAddColumnButton = screen.queryByRole('button', { name: /add column/i });
       expect(hasAddColumnButton).toBeInTheDocument();
 

--- a/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
+++ b/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
@@ -4,8 +4,8 @@ import { redirect, notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import Link from "next/link";
-import { ArrowLeft, Settings, Users, Calendar } from "lucide-react";
+import { Settings, Users, Calendar } from "lucide-react";
+import { SmartBackButton } from "@/components/navigation/smart-back-button";
 import { BoardCanvas } from "@/components/board/board-canvas";
 import { BoardPresence } from "@/components/board/board-presence";
 import { BoardTimer } from "@/components/board/timer-component";
@@ -134,11 +134,7 @@ export default async function BoardPage({
       {/* Header */}
       <div className="flex items-center justify-between p-4 border-b bg-background">
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="icon" asChild>
-            <Link href="/boards">
-              <ArrowLeft className="h-4 w-4" />
-            </Link>
-          </Button>
+          <SmartBackButton fallbackPath="/boards" />
           <div>
             <h1 className="text-2xl font-bold">{board.title}</h1>
             <div className="flex items-center gap-4 text-sm text-muted-foreground">

--- a/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
+++ b/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
@@ -55,7 +55,7 @@ async function getBoard(boardId: string, userId: string): Promise<BoardWithRelat
             include: {
               author: true,
             },
-            orderBy: { createdAt: "asc" },
+            orderBy: { order: "asc" },
           },
         },
       },
@@ -64,7 +64,7 @@ async function getBoard(boardId: string, userId: string): Promise<BoardWithRelat
         include: {
           author: true,
         },
-        orderBy: { createdAt: "asc" },
+        orderBy: { order: "asc" },
       },
     },
   });

--- a/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
+++ b/retro-ai/app/(dashboard)/boards/[boardId]/page.tsx
@@ -2,13 +2,7 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { redirect, notFound } from "next/navigation";
 import { prisma } from "@/lib/prisma";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Settings, Users, Calendar } from "lucide-react";
-import { SmartBackButton } from "@/components/navigation/smart-back-button";
-import { BoardCanvas } from "@/components/board/board-canvas";
-import { BoardPresence } from "@/components/board/board-presence";
-import { BoardTimer } from "@/components/board/timer-component";
+import { BoardPageClient } from "@/components/board/board-page-client";
 import { Prisma } from "@prisma/client";
 
 type BoardWithRelations = Prisma.BoardGetPayload<{
@@ -129,56 +123,5 @@ export default async function BoardPage({
     notFound();
   }
 
-  return (
-    <div className="h-full flex flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b bg-background">
-        <div className="flex items-center gap-4">
-          <SmartBackButton fallbackPath="/boards" />
-          <div>
-            <h1 className="text-2xl font-bold">{board.title}</h1>
-            <div className="flex items-center gap-4 text-sm text-muted-foreground">
-              <div className="flex items-center">
-                <Users className="mr-1 h-3 w-3" />
-                {board.team.name}
-              </div>
-              <div className="flex items-center">
-                <Calendar className="mr-1 h-3 w-3" />
-                {new Date(board.createdAt).toLocaleDateString()}
-              </div>
-              {board.template && (
-                <Badge variant="secondary">{board.template.name}</Badge>
-              )}
-            </div>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          <BoardPresence 
-            boardId={board.id} 
-            currentUserId={session.user.id}
-          />
-          <div className="h-4 w-px bg-border" />
-          <BoardTimer 
-            boardId={board.id}
-            userId={session.user.id}
-          />
-          <div className="h-4 w-px bg-border" />
-          <Button variant="outline" size="sm">
-            <Settings className="mr-2 h-4 w-4" />
-            Settings
-          </Button>
-        </div>
-      </div>
-
-      {/* Board Canvas */}
-      <div className="flex-1 overflow-hidden">
-        <BoardCanvas
-          board={board}
-          columns={board.columns}
-          userId={session.user.id}
-          isOwner={board.createdById === session.user.id}
-        />
-      </div>
-    </div>
-  );
+  return <BoardPageClient board={board} userId={session.user.id} />;
 }

--- a/retro-ai/app/(dashboard)/boards/new/page.tsx
+++ b/retro-ai/app/(dashboard)/boards/new/page.tsx
@@ -9,7 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { toast } from "sonner";
-import { ArrowLeft } from "lucide-react";
+import { SmartBackButton } from "@/components/navigation/smart-back-button";
 import Link from "next/link";
 
 interface Team {
@@ -135,11 +135,7 @@ function NewBoardForm() {
   return (
     <div className="max-w-2xl mx-auto space-y-6">
       <div className="flex items-center gap-4">
-        <Button variant="ghost" size="icon" asChild>
-          <Link href="/boards">
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-        </Button>
+        <SmartBackButton fallbackPath="/boards" />
         <div>
           <h2 className="text-3xl font-bold tracking-tight">Create Board</h2>
           <p className="text-muted-foreground">

--- a/retro-ai/app/(dashboard)/boards/page.tsx
+++ b/retro-ai/app/(dashboard)/boards/page.tsx
@@ -47,7 +47,8 @@ export default async function BoardsPage() {
   const boards = await getUserBoards(session.user.id);
 
   return (
-    <div className="space-y-6">
+    <div className="h-full overflow-y-auto">
+      <div className="container mx-auto p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-3xl font-bold tracking-tight">Boards</h2>
@@ -136,6 +137,7 @@ export default async function BoardsPage() {
             View Archived Boards
           </Link>
         </Button>
+      </div>
       </div>
     </div>
   );

--- a/retro-ai/app/(dashboard)/dashboard/page.tsx
+++ b/retro-ai/app/(dashboard)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
-import { Plus, Users, Presentation, Clock } from "lucide-react";
+import { Plus, Users, Presentation } from "lucide-react";
 
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
@@ -48,19 +48,6 @@ export default async function DashboardPage() {
             <div className="text-2xl font-bold">0</div>
             <p className="text-xs text-muted-foreground">
               Join or create a team
-            </p>
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Recent Activity</CardTitle>
-            <Clock className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">-</div>
-            <p className="text-xs text-muted-foreground">
-              No recent activity
             </p>
           </CardContent>
         </Card>

--- a/retro-ai/app/(dashboard)/dashboard/page.tsx
+++ b/retro-ai/app/(dashboard)/dashboard/page.tsx
@@ -100,25 +100,6 @@ export default async function DashboardPage() {
         </p>
       </div>
 
-      <div className="flex justify-center">
-        <Card className="w-full max-w-md">
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Quick Actions</CardTitle>
-            <Plus className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="flex flex-col gap-2">
-              <Button asChild size="sm" className="w-full">
-                <Link href="/boards/new">New Board</Link>
-              </Button>
-              <Button asChild size="sm" variant="outline" className="w-full">
-                <Link href="/teams/new">Create Team</Link>
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
       {/* Unified Boards Section */}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">

--- a/retro-ai/app/(dashboard)/dashboard/page.tsx
+++ b/retro-ai/app/(dashboard)/dashboard/page.tsx
@@ -67,7 +67,7 @@ export default async function DashboardPage() {
           <CardContent>
             <div className="text-2xl font-bold">{boardCount}</div>
             <p className="text-xs text-muted-foreground">
-              {boardCount === 0 ? "No boards created yet" : `${boardCount} board${boardCount === 1 ? '' : 's'} available`}
+              {boardCount === 0 ? "Create your first board" : "View all boards"}
             </p>
           </CardContent>
         </Card>
@@ -80,7 +80,7 @@ export default async function DashboardPage() {
           <CardContent>
             <div className="text-2xl font-bold">{teamCount}</div>
             <p className="text-xs text-muted-foreground">
-              {teamCount === 0 ? "Join or create a team" : `Member of ${teamCount} team${teamCount === 1 ? '' : 's'}`}
+              {teamCount === 0 ? "Join or create a team" : "Manage team settings"}
             </p>
           </CardContent>
         </Card>

--- a/retro-ai/app/(dashboard)/dashboard/page.tsx
+++ b/retro-ai/app/(dashboard)/dashboard/page.tsx
@@ -115,7 +115,7 @@ export default async function DashboardPage() {
             </CardDescription>
           </div>
           <Button asChild>
-            <Link href="/boards/new">
+            <Link href="/boards/new?from=/dashboard">
               <Plus className="mr-2 h-4 w-4" />
               New Board
             </Link>
@@ -128,7 +128,7 @@ export default async function DashboardPage() {
                 No boards yet. Create your first board to get started!
               </p>
               <Button asChild>
-                <Link href="/boards/new">
+                <Link href="/boards/new?from=/dashboard">
                   <Plus className="mr-2 h-4 w-4" />
                   Create Your First Board
                 </Link>
@@ -171,7 +171,7 @@ export default async function DashboardPage() {
                             {board._count.stickies} sticky note{board._count.stickies !== 1 ? "s" : ""}
                           </p>
                           <Button asChild size="sm">
-                            <Link href={`/boards/${board.id}`}>Open Board</Link>
+                            <Link href={`/boards/${board.id}?from=/dashboard`}>Open Board</Link>
                           </Button>
                         </div>
                       </div>
@@ -208,12 +208,12 @@ export default async function DashboardPage() {
           </div>
           <div className="flex gap-2">
             <Button asChild variant="outline" size="sm">
-              <Link href="/teams/join">
+              <Link href="/teams/join?from=/dashboard">
                 Join Team
               </Link>
             </Button>
             <Button asChild size="sm">
-              <Link href="/teams/new">
+              <Link href="/teams/new?from=/dashboard">
                 <Plus className="mr-2 h-4 w-4" />
                 Create Team
               </Link>
@@ -228,13 +228,13 @@ export default async function DashboardPage() {
               </p>
               <div className="flex justify-center gap-2">
                 <Button asChild>
-                  <Link href="/teams/new">
+                  <Link href="/teams/new?from=/dashboard">
                     <Plus className="mr-2 h-4 w-4" />
                     Create Your First Team
                   </Link>
                 </Button>
                 <Button asChild variant="outline">
-                  <Link href="/teams/join">Join Team</Link>
+                  <Link href="/teams/join?from=/dashboard">Join Team</Link>
                 </Button>
               </div>
             </div>
@@ -269,7 +269,7 @@ export default async function DashboardPage() {
                               <Link href={`/teams/${team.id}`}>View Team</Link>
                             </Button>
                             <Button asChild size="sm" variant="outline" className="flex-1">
-                              <Link href={`/boards/new?teamId=${team.id}`}>New Board</Link>
+                              <Link href={`/boards/new?teamId=${team.id}&from=/dashboard`}>New Board</Link>
                             </Button>
                           </div>
                         </div>
@@ -277,13 +277,6 @@ export default async function DashboardPage() {
                     </Card>
                   );
                 })}
-              </div>
-              <div className="pt-4 border-t">
-                <Button asChild variant="outline" className="w-full">
-                  <Link href="/teams">
-                    View All Teams
-                  </Link>
-                </Button>
               </div>
             </>
           )}

--- a/retro-ai/app/(dashboard)/dashboard/page.tsx
+++ b/retro-ai/app/(dashboard)/dashboard/page.tsx
@@ -3,8 +3,9 @@ import { authOptions } from "@/lib/auth";
 import { redirect } from "next/navigation";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
-import { Plus, Users, Presentation } from "lucide-react";
+import { Plus, Users, Presentation, Calendar } from "lucide-react";
 import { prisma } from "@/lib/prisma";
 
 async function getUserStats(userId: string) {
@@ -134,28 +135,52 @@ export default async function DashboardPage() {
               </Button>
             </div>
           ) : (
-            <div className="space-y-3">
-              {recentBoards.map((board) => (
-                <div key={board.id} className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors">
-                  <div className="flex-1">
-                    <Link href={`/boards/${board.id}`} className="block">
-                      <h4 className="font-medium hover:text-primary transition-colors">{board.title}</h4>
-                      <div className="flex items-center gap-4 text-xs text-muted-foreground mt-1">
-                        <span>{board.team.name}</span>
-                        <span>{board._count.stickies} sticky note{board._count.stickies !== 1 ? 's' : ''}</span>
-                        <span>Updated {new Date(board.updatedAt).toLocaleDateString()}</span>
+            <>
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {recentBoards.map((board) => (
+                  <Card key={board.id} className="hover:shadow-lg transition-shadow">
+                    <CardHeader>
+                      <div className="flex items-start justify-between">
+                        <div className="space-y-1">
+                          <CardTitle className="line-clamp-1">{board.title}</CardTitle>
+                          <CardDescription className="line-clamp-2">
+                            {board.description || "No description"}
+                          </CardDescription>
+                        </div>
+                        {board.template && (
+                          <Badge variant="secondary" className="ml-2 shrink-0">
+                            {board.template.name}
+                          </Badge>
+                        )}
                       </div>
-                    </Link>
-                  </div>
-                  <Button asChild variant="ghost" size="sm">
-                    <Link href={`/boards/${board.id}`}>
-                      Open
-                    </Link>
-                  </Button>
-                </div>
-              ))}
+                    </CardHeader>
+                    <CardContent>
+                      <div className="space-y-3">
+                        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+                          <div className="flex items-center">
+                            <Users className="mr-1 h-3 w-3" />
+                            {board.team.name}
+                          </div>
+                          <div className="flex items-center">
+                            <Calendar className="mr-1 h-3 w-3" />
+                            {new Date(board.updatedAt).toLocaleDateString()}
+                          </div>
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <p className="text-sm text-muted-foreground">
+                            {board._count.stickies} sticky note{board._count.stickies !== 1 ? "s" : ""}
+                          </p>
+                          <Button asChild size="sm">
+                            <Link href={`/boards/${board.id}`}>Open Board</Link>
+                          </Button>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
               {boardCount > 3 && (
-                <div className="pt-2 border-t">
+                <div className="pt-4 border-t">
                   <Button asChild variant="outline" className="w-full">
                     <Link href="/boards">
                       View All {boardCount} Boards
@@ -163,7 +188,7 @@ export default async function DashboardPage() {
                   </Button>
                 </div>
               )}
-            </div>
+            </>
           )}
         </CardContent>
       </Card>
@@ -214,34 +239,53 @@ export default async function DashboardPage() {
               </div>
             </div>
           ) : (
-            <div className="space-y-3">
-              {userTeams.map((team) => (
-                <div key={team.id} className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors">
-                  <div className="flex-1">
-                    <Link href={`/teams/${team.id}`} className="block">
-                      <h4 className="font-medium hover:text-primary transition-colors">{team.name}</h4>
-                      <div className="flex items-center gap-4 text-xs text-muted-foreground mt-1">
-                        <span>{team.members.length} member{team.members.length !== 1 ? 's' : ''}</span>
-                        <span>{team._count.boards} board{team._count.boards !== 1 ? 's' : ''}</span>
-                        <span>Created {new Date(team.createdAt).toLocaleDateString()}</span>
-                      </div>
-                    </Link>
-                  </div>
-                  <Button asChild variant="ghost" size="sm">
-                    <Link href={`/teams/${team.id}`}>
-                      View
-                    </Link>
-                  </Button>
-                </div>
-              ))}
-              <div className="pt-2 border-t">
+            <>
+              <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                {userTeams.map((team) => {
+                  const userMember = team.members.find((m) => m.userId === session.user?.id);
+                  return (
+                    <Card key={team.id}>
+                      <CardHeader>
+                        <div className="flex items-start justify-between">
+                          <div>
+                            <CardTitle>{team.name}</CardTitle>
+                            <CardDescription>
+                              {team.members.length} member{team.members.length !== 1 ? "s" : ""}
+                            </CardDescription>
+                          </div>
+                          <Badge variant={userMember?.role === "OWNER" ? "default" : "secondary"}>
+                            {userMember?.role}
+                          </Badge>
+                        </div>
+                      </CardHeader>
+                      <CardContent>
+                        <div className="space-y-4">
+                          <div className="flex items-center text-sm text-muted-foreground">
+                            <Presentation className="mr-2 h-4 w-4" />
+                            {team._count.boards} board{team._count.boards !== 1 ? "s" : ""}
+                          </div>
+                          <div className="flex gap-2">
+                            <Button asChild size="sm" className="flex-1">
+                              <Link href={`/teams/${team.id}`}>View Team</Link>
+                            </Button>
+                            <Button asChild size="sm" variant="outline" className="flex-1">
+                              <Link href={`/boards/new?teamId=${team.id}`}>New Board</Link>
+                            </Button>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
+              </div>
+              <div className="pt-4 border-t">
                 <Button asChild variant="outline" className="w-full">
                   <Link href="/teams">
                     View All Teams
                   </Link>
                 </Button>
               </div>
-            </div>
+            </>
           )}
         </CardContent>
       </Card>

--- a/retro-ai/app/(dashboard)/dashboard/page.tsx
+++ b/retro-ai/app/(dashboard)/dashboard/page.tsx
@@ -14,7 +14,8 @@ export default async function DashboardPage() {
   }
 
   return (
-    <div className="space-y-6">
+    <div className="h-full overflow-y-auto">
+      <div className="container mx-auto p-6 space-y-6">
       <div>
         <h2 className="text-3xl font-bold tracking-tight">
           Welcome back, {session.user?.name || "User"}!
@@ -129,6 +130,7 @@ export default async function DashboardPage() {
             </div>
           </CardContent>
         </Card>
+      </div>
       </div>
     </div>
   );

--- a/retro-ai/app/(dashboard)/layout.tsx
+++ b/retro-ai/app/(dashboard)/layout.tsx
@@ -7,9 +7,9 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen">
+    <div className="h-screen flex flex-col">
       <Header />
-      <div className="flex h-[calc(100vh-4rem)]">
+      <div className="flex flex-1 overflow-hidden">
         <Sidebar />
         <main className="flex-1 overflow-y-auto bg-muted/10">
           <div className="container mx-auto p-6">

--- a/retro-ai/app/(dashboard)/layout.tsx
+++ b/retro-ai/app/(dashboard)/layout.tsx
@@ -11,10 +11,8 @@ export default function DashboardLayout({
       <Header />
       <div className="flex flex-1 overflow-hidden">
         <Sidebar />
-        <main className="flex-1 overflow-y-auto bg-muted/10">
-          <div className="container mx-auto p-6">
-            {children}
-          </div>
+        <main className="flex-1 overflow-hidden bg-muted/10">
+          {children}
         </main>
       </div>
     </div>

--- a/retro-ai/app/(dashboard)/teams/[teamId]/page.tsx
+++ b/retro-ai/app/(dashboard)/teams/[teamId]/page.tsx
@@ -7,8 +7,9 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import Link from "next/link";
-import { ArrowLeft, Plus, Shield, Crown, User } from "lucide-react";
+import { Plus, Shield, Crown, User } from "lucide-react";
 import { TeamInviteDialog } from "@/components/teams/team-invite-dialog";
+import { SmartBackButton } from "@/components/navigation/smart-back-button";
 
 async function getTeam(teamId: string, userId: string) {
   const team = await prisma.team.findUnique({
@@ -85,11 +86,7 @@ export default async function TeamPage({
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          <Button variant="ghost" size="icon" asChild>
-            <Link href="/teams">
-              <ArrowLeft className="h-4 w-4" />
-            </Link>
-          </Button>
+          <SmartBackButton fallbackPath="/teams" />
           <div>
             <h2 className="text-3xl font-bold tracking-tight">{team.name}</h2>
             <p className="text-muted-foreground">

--- a/retro-ai/app/(dashboard)/teams/join/page.tsx
+++ b/retro-ai/app/(dashboard)/teams/join/page.tsx
@@ -7,8 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { toast } from "sonner";
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
+import { SmartBackButton } from "@/components/navigation/smart-back-button";
 
 export default function JoinTeamPage() {
   const [teamCode, setTeamCode] = useState("");
@@ -54,11 +53,7 @@ export default function JoinTeamPage() {
   return (
     <div className="max-w-2xl mx-auto space-y-6">
       <div className="flex items-center gap-4">
-        <Button variant="ghost" size="icon" asChild>
-          <Link href="/teams">
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-        </Button>
+        <SmartBackButton fallbackPath="/teams" />
         <div>
           <h2 className="text-3xl font-bold tracking-tight">Join Team</h2>
           <p className="text-muted-foreground">

--- a/retro-ai/app/(dashboard)/teams/new/page.tsx
+++ b/retro-ai/app/(dashboard)/teams/new/page.tsx
@@ -7,8 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { toast } from "sonner";
-import { ArrowLeft } from "lucide-react";
-import Link from "next/link";
+import { SmartBackButton } from "@/components/navigation/smart-back-button";
 
 export default function NewTeamPage() {
   const [teamName, setTeamName] = useState("");
@@ -54,11 +53,7 @@ export default function NewTeamPage() {
   return (
     <div className="max-w-2xl mx-auto space-y-6">
       <div className="flex items-center gap-4">
-        <Button variant="ghost" size="icon" asChild>
-          <Link href="/teams">
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-        </Button>
+        <SmartBackButton fallbackPath="/teams" />
         <div>
           <h2 className="text-3xl font-bold tracking-tight">Create Team</h2>
           <p className="text-muted-foreground">

--- a/retro-ai/app/(dashboard)/teams/page.tsx
+++ b/retro-ai/app/(dashboard)/teams/page.tsx
@@ -44,7 +44,8 @@ export default async function TeamsPage() {
   const teams = await getUserTeams(session.user.id);
 
   return (
-    <div className="space-y-6">
+    <div className="h-full overflow-y-auto">
+      <div className="container mx-auto p-6 space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-3xl font-bold tracking-tight">Teams</h2>
@@ -125,6 +126,7 @@ export default async function TeamsPage() {
           })}
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/retro-ai/app/api/stickies/[stickyId]/route.ts
+++ b/retro-ai/app/api/stickies/[stickyId]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { calculateStickyOrder, type MoveIntent } from "@/lib/lexicographic-order";
 
 export async function PATCH(
   req: Request,
@@ -18,7 +19,17 @@ export async function PATCH(
       );
     }
 
-    const { content, color, columnId, positionX, positionY } = await req.json();
+    const { 
+      content, 
+      color, 
+      columnId, 
+      positionX, 
+      positionY,
+      // New order-related fields
+      insertAfterStickyId,
+      insertBeforeStickyId,
+      insertAtPosition
+    } = await req.json();
 
     // Find the sticky note
     const sticky = await prisma.sticky.findUnique({
@@ -58,6 +69,30 @@ export async function PATCH(
     const isEditingContent = content !== undefined || color !== undefined;
     const isNonAuthorEdit = isEditingContent && sticky.authorId !== session.user.id;
     
+    // Calculate new order if this is a move operation
+    let newOrder: number | undefined = undefined;
+    
+    if (columnId !== undefined && (insertAfterStickyId || insertBeforeStickyId || insertAtPosition)) {
+      // Get existing stickies in the target column
+      const existingStickies = await prisma.sticky.findMany({
+        where: { 
+          columnId: columnId,
+          id: { not: stickyId } // Exclude the sticky being moved
+        },
+        select: { id: true, order: true },
+        orderBy: { order: 'asc' }
+      });
+
+      const moveIntent: MoveIntent = {
+        targetColumnId: columnId,
+        ...(insertAfterStickyId && { insertAfterStickyId }),
+        ...(insertBeforeStickyId && { insertBeforeStickyId }),
+        ...(insertAtPosition && { insertAtPosition })
+      };
+
+      newOrder = calculateStickyOrder(existingStickies, moveIntent);
+    }
+    
     // Update sticky note
     const updatedSticky = await prisma.sticky.update({
       where: { id: stickyId },
@@ -67,6 +102,7 @@ export async function PATCH(
         ...(columnId !== undefined && { columnId }),
         ...(positionX !== undefined && { positionX }),
         ...(positionY !== undefined && { positionY }),
+        ...(newOrder !== undefined && { order: newOrder }),
         // Add editor to editedBy array if they're not the original author
         // and not already in the array
         ...(isNonAuthorEdit && !sticky.editedBy.includes(session.user.id) && {

--- a/retro-ai/app/api/stickies/[stickyId]/route.ts
+++ b/retro-ai/app/api/stickies/[stickyId]/route.ts
@@ -19,6 +19,7 @@ export async function PATCH(
       );
     }
 
+    const requestBody = await req.json();
     const { 
       content, 
       color, 
@@ -29,7 +30,18 @@ export async function PATCH(
       insertAfterStickyId,
       insertBeforeStickyId,
       insertAtPosition
-    } = await req.json();
+    } = requestBody;
+
+    // Debug logging for move intent
+    if (columnId !== undefined) {
+      console.log(`[STICKY-MOVE] ${stickyId} -> Column: ${columnId || 'unassigned'}`);
+      console.log(`[STICKY-MOVE] Move intent:`, {
+        insertAfterStickyId,
+        insertBeforeStickyId,
+        insertAtPosition
+      });
+      console.log(`[STICKY-MOVE] Full request body:`, requestBody);
+    }
 
     // Find the sticky note
     const sticky = await prisma.sticky.findUnique({
@@ -90,7 +102,12 @@ export async function PATCH(
         ...(insertAtPosition && { insertAtPosition })
       };
 
+      console.log(`[STICKY-MOVE] Existing stickies in column:`, existingStickies.length);
+      console.log(`[STICKY-MOVE] Calculated move intent:`, moveIntent);
+
       newOrder = calculateStickyOrder(existingStickies, moveIntent);
+      
+      console.log(`[STICKY-MOVE] Calculated new order:`, newOrder);
     }
     
     // Update sticky note

--- a/retro-ai/app/api/stickies/[stickyId]/route.ts
+++ b/retro-ai/app/api/stickies/[stickyId]/route.ts
@@ -32,16 +32,6 @@ export async function PATCH(
       insertAtPosition
     } = requestBody;
 
-    // Debug logging for move intent
-    if (columnId !== undefined) {
-      console.log(`[STICKY-MOVE] ${stickyId} -> Column: ${columnId || 'unassigned'}`);
-      console.log(`[STICKY-MOVE] Move intent:`, {
-        insertAfterStickyId,
-        insertBeforeStickyId,
-        insertAtPosition
-      });
-      console.log(`[STICKY-MOVE] Full request body:`, requestBody);
-    }
 
     // Find the sticky note
     const sticky = await prisma.sticky.findUnique({
@@ -102,12 +92,7 @@ export async function PATCH(
         ...(insertAtPosition && { insertAtPosition })
       };
 
-      console.log(`[STICKY-MOVE] Existing stickies in column:`, existingStickies.length);
-      console.log(`[STICKY-MOVE] Calculated move intent:`, moveIntent);
-
       newOrder = calculateStickyOrder(existingStickies, moveIntent);
-      
-      console.log(`[STICKY-MOVE] Calculated new order:`, newOrder);
     }
     
     // Update sticky note

--- a/retro-ai/app/globals.css
+++ b/retro-ai/app/globals.css
@@ -116,6 +116,7 @@
   * {
     @apply border-border outline-ring/50;
   }
+
   body {
     @apply bg-background text-foreground;
   }
@@ -123,13 +124,16 @@
 
 /* Pulsating animation for move indicator */
 @keyframes pulse-move {
-  0%, 100% { 
-    opacity: 1; 
-    transform: scale(1); 
+
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1);
   }
-  50% { 
-    opacity: 0.7; 
-    transform: scale(1.02); 
+
+  50% {
+    opacity: 0.7;
+    transform: scale(1.02);
   }
 }
 
@@ -142,8 +146,18 @@
   position: fixed !important;
   z-index: 40 !important;
   pointer-events: none;
-  transition: transform 300ms cubic-bezier(0.2, 0, 0.2, 1);
+  transition: left 300ms cubic-bezier(0.2, 0, 0.2, 1), top 300ms cubic-bezier(0.2, 0, 0.2, 1);
   box-shadow: 0 8px 25px -5px rgba(0, 0, 0, 0.15), 0 8px 10px -6px rgba(0, 0, 0, 0.1);
+  transform: scale(0.4) !important;
+  width: 200px !important;
+  height: 200px !important;
+  overflow: hidden !important;
+  border-radius: var(--radius) !important;
+}
+
+.sticky-remote-settling {
+  transition: transform 400ms cubic-bezier(0.25, 0.1, 0.25, 1) !important;
+  transform: scale(1) !important;
 }
 
 .sticky-remote-entering {
@@ -170,12 +184,15 @@
   }
 }
 
+
 /* Respect user's motion preferences */
 @media (prefers-reduced-motion: reduce) {
-  .sticky-remote-moving {
+  .sticky-remote-moving,
+  .sticky-remote-settling {
     transition: none;
+    transform: scale(1) !important;
   }
-  
+
   .sticky-remote-entering,
   .sticky-remote-leaving {
     animation: none;

--- a/retro-ai/components/board/board-canvas.tsx
+++ b/retro-ai/components/board/board-canvas.tsx
@@ -13,7 +13,6 @@ import {
 } from "@dnd-kit/core";
 import { arrayMove, SortableContext } from "@dnd-kit/sortable";
 import { Column } from "./column";
-import { CreateStickyDialog } from "./create-sticky-dialog";
 import { CreateColumnDialog } from "./create-column-dialog";
 import { StickyNote } from "./sticky-note";
 import { UnassignedArea } from "./unassigned-area";
@@ -166,7 +165,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
   const [columns, setColumns] = useState(initialColumns);
   const [unassignedStickies, setUnassignedStickies] = useState(board.stickies);
   const [activeId, setActiveId] = useState<string | null>(null);
-  const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [showCreateColumnDialog, setShowCreateColumnDialog] = useState(false);
   const [moveIndicators, setMoveIndicators] = useState<Record<string, { movedBy: string; timestamp: number }>>({});
   
@@ -975,26 +973,7 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
           )}
         </div>
 
-        {/* Floating Add Button */}
-        <Button
-          className="fixed bottom-6 right-6 h-14 w-14 rounded-full shadow-lg"
-          size="icon"
-          onClick={() => setShowCreateDialog(true)}
-          data-testid="floating-add-note-button"
-        >
-          <Plus className="h-6 w-6" />
-        </Button>
-
-        <CreateStickyDialog
-          open={showCreateDialog}
-          onOpenChange={setShowCreateDialog}
-          boardId={board.id}
-          columns={columns}
-          onStickyCreated={() => {
-            setShowCreateDialog(false);
-            // No router.refresh() needed - WebSocket handles real-time UI updates for all users including creator
-          }}
-        />
+        {/* Removed floating button - now in header */}
 
         <CreateColumnDialog
           open={showCreateColumnDialog}

--- a/retro-ai/components/board/board-canvas.tsx
+++ b/retro-ai/components/board/board-canvas.tsx
@@ -184,17 +184,13 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
     onStickyMoved: useCallback((data: MovementEvent) => {
       // Only update if this movement wasn't initiated by us
       if (isLocalMovement.current || data.userId === userId) {
-        console.log(`[MULTI-USER] Skipping movement for ${data.stickyId} - local movement or same user`);
         return;
       }
 
       // Skip if already animating this sticky to prevent conflicts
       if (flipAnimation.isAnimating(data.stickyId)) {
-        console.log(`[MULTI-USER] Skipping animation for ${data.stickyId} - already in progress`);
         return;
       }
-
-      console.log(`[MULTI-USER] Processing remote movement from ${data.userName}:`, data);
 
       // Set move indicator for this sticky
       if (data.userName) {
@@ -225,16 +221,12 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
               if (data.order !== undefined) {
                 stickyToReorder.order = data.order;
               }
-              console.log(`[MULTI-USER] Reordering sticky ${data.stickyId} within unassigned area`);
-              
               // Remove from current position and add with new order
               const filtered = prevUnassigned.filter(s => s.id !== data.stickyId);
               const result = [...filtered, stickyToReorder];
               
               // Sort by order to maintain consistent positioning
               result.sort((a, b) => a.order - b.order);
-              
-              console.log(`[MULTI-USER] Updated unassigned area with sticky ${data.stickyId} at order ${stickyToReorder.order}`);
               return result;
             } else {
               // Sticky is not in unassigned, so it must be coming from a column
@@ -256,8 +248,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                 if (data.order !== undefined) {
                   stickyFromColumn.order = data.order;
                 }
-                console.log(`[MULTI-USER] Found sticky ${data.stickyId} in column ${column.id}, moving to unassigned`);
-                
                 // Add to unassigned area immediately
                 setUnassignedStickies(prevUnassigned => {
                   // Double-check it's not already there
@@ -268,7 +258,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                   const result = [...prevUnassigned, stickyFromColumn!];
                   result.sort((a, b) => a.order - b.order);
                   
-                  console.log(`[MULTI-USER] Added sticky ${data.stickyId} to unassigned with order ${stickyFromColumn!.order}`);
                   return result;
                 });
                 
@@ -295,8 +284,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
               if (data.order !== undefined) {
                 stickyFromUnassigned.order = data.order;
               }
-              console.log(`[MULTI-USER] Found sticky ${data.stickyId} in unassigned area, moving to column ${data.columnId}`);
-              
               // Add to target column immediately
               setColumns(prevColumns => {
                 return prevColumns.map(column => {
@@ -311,8 +298,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                     
                     // Sort by order
                     newStickies.sort((a, b) => a.order - b.order);
-                    
-                    console.log(`[MULTI-USER] Added sticky ${data.stickyId} to column ${data.columnId} with order ${stickyFromUnassigned.order}`);
                     
                     return {
                       ...column,
@@ -344,7 +329,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                 if (data.order !== undefined) {
                   stickyFromColumn.order = data.order;
                 }
-                console.log(`[MULTI-USER] Found sticky ${data.stickyId} in column ${column.id}, moving to column ${data.columnId}`);
                 // Remove from source column
                 return {
                   ...column,
@@ -369,8 +353,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
                 // Sort by order
                 newStickies.sort((a, b) => a.order - b.order);
                 
-                console.log(`[MULTI-USER] Added sticky ${data.stickyId} to column ${data.columnId} with order ${stickyFromColumn.order}`);
-                
                 return {
                   ...column,
                   stickies: newStickies,
@@ -388,7 +370,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
         return;
       }
 
-      console.log("Received column rename event:", data);
 
       // Update the column title in local state
       setColumns(prevColumns =>
@@ -405,7 +386,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
         return;
       }
 
-      console.log("Received column delete event:", data);
 
       // For remote users, we need to move the stickies to unassigned and remove the column
       setColumns(prevColumns => {
@@ -462,7 +442,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
     }, []),
     onStickyCreated: useCallback((data: StickyCreateEvent) => {
       // Process all sticky creations (including our own) for consistency
-      console.log("Received note creation event:", data);
 
       // Create the new sticky object from the event data
       const newSticky = {
@@ -819,12 +798,10 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
           // AFTER the active item is removed. Since activeIndex < overIndex, removing activeIndex
           // shifts everything after it down by 1, so the item we want is currently at overIndex
           insertAfterIndex = overIndex;
-          console.log(`[LOCAL-USER] Moving down: activeIndex=${activeIndex}, overIndex=${overIndex}, insertAfterIndex=${insertAfterIndex}`);
         } else {
           // Moving up: insert after the item that's currently at overIndex-1
           // (since we remove activeIndex which is after overIndex, overIndex-1 stays in place)
           insertAfterIndex = overIndex - 1;
-          console.log(`[LOCAL-USER] Moving up: activeIndex=${activeIndex}, overIndex=${overIndex}, insertAfterIndex=${insertAfterIndex}`);
         }
         
         if (insertAfterIndex >= 0 && insertAfterIndex < originalOverItems.length) {
@@ -832,21 +809,17 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
           // Make sure we're not trying to insert after ourselves
           if (targetSticky.id !== activeId) {
             moveIntent.insertAfterStickyId = targetSticky.id;
-            console.log(`[LOCAL-USER] Moving ${activeId}: insert after ${targetSticky.id} (index ${insertAfterIndex})`);
           } else {
             // If we're trying to insert after ourselves, we need to adjust
             if (insertAfterIndex > 0) {
               const alternativeSticky = originalOverItems[insertAfterIndex - 1];
               moveIntent.insertAfterStickyId = alternativeSticky.id;
-              console.log(`[LOCAL-USER] Moving ${activeId}: adjusted to insert after ${alternativeSticky.id}`);
             } else {
               moveIntent.insertAtPosition = 'start';
-              console.log(`[LOCAL-USER] Moving ${activeId}: adjusted to start position`);
             }
           }
         } else {
           moveIntent.insertAtPosition = insertAfterIndex < 0 ? 'start' : 'end';
-          console.log(`[LOCAL-USER] Moving ${activeId}: using position ${moveIntent.insertAtPosition}`);
         }
       }
     } else {
@@ -883,8 +856,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
       // Mark this as a local movement to prevent echo
       isLocalMovement.current = true;
       
-      console.log(`[LOCAL-USER] Sending move intent for ${activeId}:`, moveIntent);
-      
       const response = await fetch(`/api/stickies/${activeId}`, {
         method: "PATCH",
         headers: {
@@ -900,8 +871,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
       const result = await response.json();
       const calculatedOrder = result.sticky.order;
 
-      console.log(`[LOCAL-USER] Server calculated order ${calculatedOrder} for sticky ${activeId}`);
-
       // Update local state with server-calculated order
       if (targetColumnId === null) {
         // Update unassigned stickies with correct order
@@ -912,7 +881,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
               : sticky
           ).sort((a, b) => a.order - b.order)
         );
-        console.log(`[LOCAL-USER] Updated local unassigned sticky ${activeId} with order ${calculatedOrder}`);
       } else {
         // Update column stickies with correct order
         setColumns(prevColumns => 
@@ -929,7 +897,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
               : column
           )
         );
-        console.log(`[LOCAL-USER] Updated local column sticky ${activeId} with order ${calculatedOrder}`);
       }
 
       // Emit socket event with server-calculated order
@@ -940,7 +907,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
           order: calculatedOrder,
           boardId: board.id,
         });
-        console.log(`[LOCAL-USER] Emitted movement event to other users:`, { stickyId: activeId, columnId: targetColumnId, order: calculatedOrder, boardId: board.id });
       }
       
       // No router.refresh() needed - WebSocket handles real-time UI updates
@@ -953,7 +919,6 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
     } finally {
       // Reset the local movement flag after a short delay
       setTimeout(() => {
-        console.log(`[LOCAL-USER] Resetting local movement flag for ${activeId}`);
         isLocalMovement.current = false;
       }, 100);
     }

--- a/retro-ai/components/board/board-canvas.tsx
+++ b/retro-ai/components/board/board-canvas.tsx
@@ -842,6 +842,36 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
 
       console.log(`[LOCAL-USER] Server calculated order ${calculatedOrder} for sticky ${activeId}`);
 
+      // Update local state with server-calculated order
+      if (targetColumnId === null) {
+        // Update unassigned stickies with correct order
+        setUnassignedStickies(prev => 
+          prev.map(sticky => 
+            sticky.id === activeId 
+              ? { ...sticky, order: calculatedOrder }
+              : sticky
+          ).sort((a, b) => a.order - b.order)
+        );
+        console.log(`[LOCAL-USER] Updated local unassigned sticky ${activeId} with order ${calculatedOrder}`);
+      } else {
+        // Update column stickies with correct order
+        setColumns(prevColumns => 
+          prevColumns.map(column => 
+            column.id === targetColumnId
+              ? {
+                  ...column,
+                  stickies: column.stickies.map(sticky =>
+                    sticky.id === activeId
+                      ? { ...sticky, order: calculatedOrder }
+                      : sticky
+                  ).sort((a, b) => a.order - b.order)
+                }
+              : column
+          )
+        );
+        console.log(`[LOCAL-USER] Updated local column sticky ${activeId} with order ${calculatedOrder}`);
+      }
+
       // Emit socket event with server-calculated order
       if (isConnected) {
         emitStickyMoved({

--- a/retro-ai/components/board/board-canvas.tsx
+++ b/retro-ai/components/board/board-canvas.tsx
@@ -935,8 +935,8 @@ export function BoardCanvas({ board, columns: initialColumns, userId, isOwner }:
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
     >
-      <div className="h-full p-6 bg-gradient-to-br from-background to-muted/20">
-        <div className="h-full flex gap-6 overflow-x-auto">
+      <div className="h-full p-6 bg-gradient-to-br from-background to-muted/20 overflow-auto">
+        <div className="min-h-full flex gap-6" style={{ minWidth: 'max-content' }}>
           {/* Unassigned Area */}
           <UnassignedArea
             stickies={unassignedStickies}

--- a/retro-ai/components/board/board-page-client.tsx
+++ b/retro-ai/components/board/board-page-client.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Settings, Users, Calendar, Plus } from "lucide-react";
+import { SmartBackButton } from "@/components/navigation/smart-back-button";
+import { BoardCanvas } from "@/components/board/board-canvas";
+import { BoardPresence } from "@/components/board/board-presence";
+import { BoardTimer } from "@/components/board/timer-component";
+import { CreateStickyDialog } from "@/components/board/create-sticky-dialog";
+import { Prisma } from "@prisma/client";
+
+type BoardWithRelations = Prisma.BoardGetPayload<{
+  include: {
+    team: {
+      include: {
+        members: true;
+      };
+    };
+    template: true;
+    columns: {
+      include: {
+        stickies: {
+          include: {
+            author: true;
+          };
+        };
+      };
+    };
+    stickies: {
+      include: {
+        author: true;
+      };
+    };
+  };
+}>;
+
+interface BoardPageClientProps {
+  board: BoardWithRelations;
+  userId: string;
+}
+
+export function BoardPageClient({ board, userId }: BoardPageClientProps) {
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+
+  return (
+    <div className="h-full flex flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 border-b bg-background">
+        <div className="flex items-center gap-4">
+          <SmartBackButton fallbackPath="/boards" />
+          <div className="flex items-center gap-4">
+            <div>
+              <h1 className="text-xl sm:text-2xl font-bold">{board.title}</h1>
+              <div className="flex items-center gap-2 sm:gap-4 text-sm text-muted-foreground">
+                <div className="flex items-center">
+                  <Users className="mr-1 h-3 w-3" />
+                  <span className="hidden sm:inline">{board.team.name}</span>
+                  <span className="sm:hidden">{board.team.name.length > 10 ? board.team.name.substring(0, 10) + '...' : board.team.name}</span>
+                </div>
+                <div className="flex items-center">
+                  <Calendar className="mr-1 h-3 w-3" />
+                  <span className="hidden sm:inline">{new Date(board.createdAt).toLocaleDateString()}</span>
+                  <span className="sm:hidden">{new Date(board.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+                </div>
+                {board.template && (
+                  <Badge variant="secondary" className="hidden sm:inline-flex">{board.template.name}</Badge>
+                )}
+              </div>
+            </div>
+            <Button
+              className="ml-2 sm:ml-4 flex-shrink-0"
+              size="sm"
+              onClick={() => setShowCreateDialog(true)}
+              data-testid="header-add-note-button"
+            >
+              <Plus className="mr-1 sm:mr-2 h-4 w-4" />
+              <span className="hidden sm:inline">Add Note</span>
+              <span className="sm:hidden">Add</span>
+            </Button>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <BoardPresence 
+            boardId={board.id} 
+            currentUserId={userId}
+          />
+          <div className="h-4 w-px bg-border" />
+          <BoardTimer 
+            boardId={board.id}
+            userId={userId}
+          />
+          <div className="h-4 w-px bg-border" />
+          <Button variant="outline" size="sm">
+            <Settings className="mr-2 h-4 w-4" />
+            Settings
+          </Button>
+        </div>
+      </div>
+
+      {/* Board Canvas */}
+      <div className="flex-1 overflow-hidden">
+        <BoardCanvas
+          board={board}
+          columns={board.columns}
+          userId={userId}
+          isOwner={board.createdById === userId}
+        />
+      </div>
+
+      <CreateStickyDialog
+        open={showCreateDialog}
+        onOpenChange={setShowCreateDialog}
+        boardId={board.id}
+        columns={board.columns}
+        onStickyCreated={() => {
+          setShowCreateDialog(false);
+        }}
+      />
+    </div>
+  );
+}

--- a/retro-ai/components/navigation/smart-back-button.tsx
+++ b/retro-ai/components/navigation/smart-back-button.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+interface SmartBackButtonProps {
+  fallbackPath: string;
+  className?: string;
+}
+
+export function SmartBackButton({ fallbackPath, className }: SmartBackButtonProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [backPath, setBackPath] = useState<string>(fallbackPath);
+
+  useEffect(() => {
+    // Check for explicit back path in search params
+    const fromParam = searchParams.get("from");
+    if (fromParam) {
+      setBackPath(decodeURIComponent(fromParam));
+      return;
+    }
+
+    // Check if we can use browser history
+    if (typeof window !== "undefined" && window.history.length > 1) {
+      // If referrer is from the same origin and not the login page, use browser back
+      const referrer = document.referrer;
+      if (referrer && referrer.startsWith(window.location.origin) && !referrer.includes("/login")) {
+        // Use browser back for same-origin referrers
+        setBackPath("BROWSER_BACK");
+        return;
+      }
+    }
+
+    // Fall back to the provided fallback path
+    setBackPath(fallbackPath);
+  }, [searchParams, fallbackPath]);
+
+  const handleBack = () => {
+    if (backPath === "BROWSER_BACK") {
+      router.back();
+    } else {
+      router.push(backPath);
+    }
+  };
+
+  // If we're using browser back, render a button with onClick
+  if (backPath === "BROWSER_BACK") {
+    return (
+      <Button variant="ghost" size="icon" onClick={handleBack} className={className}>
+        <ArrowLeft className="h-4 w-4" />
+      </Button>
+    );
+  }
+
+  // Otherwise, render a Link
+  return (
+    <Button variant="ghost" size="icon" asChild className={className}>
+      <Link href={backPath}>
+        <ArrowLeft className="h-4 w-4" />
+      </Link>
+    </Button>
+  );
+}

--- a/retro-ai/hooks/use-socket.ts
+++ b/retro-ai/hooks/use-socket.ts
@@ -8,6 +8,7 @@ interface MovementEvent {
   columnId: string | null;
   positionX?: number;
   positionY?: number;
+  order?: number;
   boardId?: string;
   userId: string;
   timestamp: number;

--- a/retro-ai/lib/lexicographic-order.test.ts
+++ b/retro-ai/lib/lexicographic-order.test.ts
@@ -1,0 +1,193 @@
+import {
+  calculateStickyOrder,
+  needsRebalancing,
+  rebalanceOrders,
+  generateInitialOrders,
+  type StickyOrderInfo
+} from './lexicographic-order';
+
+describe('Lexicographic Order Utilities', () => {
+  const createSticky = (id: string, order: number): StickyOrderInfo => ({ id, order });
+
+  describe('calculateStickyOrder', () => {
+    it('should return 1000 for empty column', () => {
+      const result = calculateStickyOrder([], { targetColumnId: 'col1' });
+      expect(result).toBe(1000.0);
+    });
+
+    it('should insert at the beginning when insertAtPosition is start', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAtPosition: 'start' 
+      });
+      expect(result).toBe(500.0); // 1000 / 2
+    });
+
+    it('should insert at the end when insertAtPosition is end', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAtPosition: 'end' 
+      });
+      expect(result).toBe(3000.0); // 2000 + 1000
+    });
+
+    it('should insert after specific sticky in middle', () => {
+      const stickies = [
+        createSticky('1', 1000), 
+        createSticky('2', 2000), 
+        createSticky('3', 3000)
+      ];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAfterStickyId: '2' 
+      });
+      expect(result).toBe(2500.0); // (2000 + 3000) / 2
+    });
+
+    it('should insert after last sticky', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAfterStickyId: '2' 
+      });
+      expect(result).toBe(3000.0); // 2000 + 1000
+    });
+
+    it('should insert before specific sticky in middle', () => {
+      const stickies = [
+        createSticky('1', 1000), 
+        createSticky('2', 2000), 
+        createSticky('3', 3000)
+      ];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertBeforeStickyId: '2' 
+      });
+      expect(result).toBe(1500.0); // (1000 + 2000) / 2
+    });
+
+    it('should insert before first sticky', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertBeforeStickyId: '1' 
+      });
+      expect(result).toBe(500.0); // 1000 / 2
+    });
+
+    it('should throw error when insertAfterStickyId not found', () => {
+      const stickies = [createSticky('1', 1000)];
+      expect(() => {
+        calculateStickyOrder(stickies, { 
+          targetColumnId: 'col1', 
+          insertAfterStickyId: 'nonexistent' 
+        });
+      }).toThrow('Sticky with id nonexistent not found in target column');
+    });
+
+    it('should throw error when insertBeforeStickyId not found', () => {
+      const stickies = [createSticky('1', 1000)];
+      expect(() => {
+        calculateStickyOrder(stickies, { 
+          targetColumnId: 'col1', 
+          insertBeforeStickyId: 'nonexistent' 
+        });
+      }).toThrow('Sticky with id nonexistent not found in target column');
+    });
+
+    it('should handle unsorted input by sorting first', () => {
+      const stickies = [
+        createSticky('2', 2000), 
+        createSticky('1', 1000), 
+        createSticky('3', 3000)
+      ];
+      const result = calculateStickyOrder(stickies, { 
+        targetColumnId: 'col1', 
+        insertAfterStickyId: '1' 
+      });
+      expect(result).toBe(1500.0); // Should insert between 1000 and 2000
+    });
+  });
+
+  describe('needsRebalancing', () => {
+    it('should return false for empty array', () => {
+      expect(needsRebalancing([])).toBe(false);
+    });
+
+    it('should return false for single item', () => {
+      expect(needsRebalancing([createSticky('1', 1000)])).toBe(false);
+    });
+
+    it('should return false when gaps are sufficient', () => {
+      const stickies = [createSticky('1', 1000), createSticky('2', 2000)];
+      expect(needsRebalancing(stickies)).toBe(false);
+    });
+
+    it('should return true when gaps are too small', () => {
+      const stickies = [
+        createSticky('1', 1000), 
+        createSticky('2', 1000.0000001) // Very small gap
+      ];
+      expect(needsRebalancing(stickies)).toBe(true);
+    });
+  });
+
+  describe('rebalanceOrders', () => {
+    it('should return empty array for empty input', () => {
+      expect(rebalanceOrders([])).toEqual([]);
+    });
+
+    it('should rebalance orders evenly', () => {
+      const stickies = [
+        createSticky('1', 1000.1), 
+        createSticky('2', 1000.2), 
+        createSticky('3', 1000.3)
+      ];
+      const result = rebalanceOrders(stickies);
+      
+      expect(result).toEqual([
+        { id: '1', order: 1000.0 },
+        { id: '2', order: 2000.0 },
+        { id: '3', order: 3000.0 }
+      ]);
+    });
+
+    it('should maintain original order when rebalancing', () => {
+      const stickies = [
+        createSticky('3', 3000), 
+        createSticky('1', 1000), 
+        createSticky('2', 2000)
+      ];
+      const result = rebalanceOrders(stickies);
+      
+      // Should be sorted by order, not by input order
+      expect(result[0].id).toBe('1');
+      expect(result[1].id).toBe('2'); 
+      expect(result[2].id).toBe('3');
+    });
+  });
+
+  describe('generateInitialOrders', () => {
+    it('should generate correct number of orders', () => {
+      const orders = generateInitialOrders(3);
+      expect(orders).toHaveLength(3);
+    });
+
+    it('should generate orders with default values', () => {
+      const orders = generateInitialOrders(3);
+      expect(orders).toEqual([1000.0, 2000.0, 3000.0]);
+    });
+
+    it('should generate orders with custom start and increment', () => {
+      const orders = generateInitialOrders(2, 500.0, 250.0);
+      expect(orders).toEqual([500.0, 750.0]);
+    });
+
+    it('should return empty array for zero count', () => {
+      const orders = generateInitialOrders(0);
+      expect(orders).toEqual([]);
+    });
+  });
+});

--- a/retro-ai/lib/lexicographic-order.ts
+++ b/retro-ai/lib/lexicographic-order.ts
@@ -1,0 +1,153 @@
+/**
+ * Lexicographic ordering utility for sticky notes within columns
+ * 
+ * This utility provides functions to calculate order values for sticky notes
+ * when they are moved within columns. It uses floating-point arithmetic to
+ * enable insertion between any two positions without requiring renumbering
+ * of existing items.
+ */
+
+export interface StickyOrderInfo {
+  id: string;
+  order: number;
+}
+
+export interface MoveIntent {
+  targetColumnId: string | null;
+  insertAfterStickyId?: string;
+  insertBeforeStickyId?: string;
+  insertAtPosition?: 'start' | 'end';
+}
+
+/**
+ * Calculate the order value for a sticky note based on its target position
+ * @param existingStickies Array of existing stickies in the target column, ordered by their order field
+ * @param moveIntent Description of where to insert the sticky
+ * @returns The calculated order value
+ */
+export function calculateStickyOrder(
+  existingStickies: StickyOrderInfo[],
+  moveIntent: MoveIntent
+): number {
+  // Sort existing stickies by order to ensure proper positioning
+  const sortedStickies = [...existingStickies].sort((a, b) => a.order - b.order);
+  
+  // Handle empty column
+  if (sortedStickies.length === 0) {
+    return 1000.0; // Start with a reasonable base value
+  }
+
+  // Handle insertion at the start
+  if (moveIntent.insertAtPosition === 'start' || moveIntent.insertBeforeStickyId === sortedStickies[0].id) {
+    const firstOrder = sortedStickies[0].order;
+    return firstOrder / 2.0; // Insert before first item
+  }
+
+  // Handle insertion at the end
+  if (moveIntent.insertAtPosition === 'end' || moveIntent.insertAfterStickyId === sortedStickies[sortedStickies.length - 1].id) {
+    const lastOrder = sortedStickies[sortedStickies.length - 1].order;
+    return lastOrder + 1000.0; // Insert after last item
+  }
+
+  // Handle insertion after a specific sticky
+  if (moveIntent.insertAfterStickyId) {
+    const targetIndex = sortedStickies.findIndex(s => s.id === moveIntent.insertAfterStickyId);
+    
+    if (targetIndex === -1) {
+      throw new Error(`Sticky with id ${moveIntent.insertAfterStickyId} not found in target column`);
+    }
+
+    const currentOrder = sortedStickies[targetIndex].order;
+    
+    // If this is the last item, add to the end
+    if (targetIndex === sortedStickies.length - 1) {
+      return currentOrder + 1000.0;
+    }
+    
+    // Insert between current and next item
+    const nextOrder = sortedStickies[targetIndex + 1].order;
+    return (currentOrder + nextOrder) / 2.0;
+  }
+
+  // Handle insertion before a specific sticky
+  if (moveIntent.insertBeforeStickyId) {
+    const targetIndex = sortedStickies.findIndex(s => s.id === moveIntent.insertBeforeStickyId);
+    
+    if (targetIndex === -1) {
+      throw new Error(`Sticky with id ${moveIntent.insertBeforeStickyId} not found in target column`);
+    }
+
+    const currentOrder = sortedStickies[targetIndex].order;
+    
+    // If this is the first item, insert before it
+    if (targetIndex === 0) {
+      return currentOrder / 2.0;
+    }
+    
+    // Insert between previous and current item
+    const prevOrder = sortedStickies[targetIndex - 1].order;
+    return (prevOrder + currentOrder) / 2.0;
+  }
+
+  // Default: append to end
+  const lastOrder = sortedStickies[sortedStickies.length - 1].order;
+  return lastOrder + 1000.0;
+}
+
+/**
+ * Check if the order values in a column need rebalancing
+ * This happens when the precision becomes too small for reliable insertion
+ * @param stickies Array of stickies in the column
+ * @returns true if rebalancing is needed
+ */
+export function needsRebalancing(stickies: StickyOrderInfo[]): boolean {
+  if (stickies.length < 2) return false;
+  
+  const sortedStickies = [...stickies].sort((a, b) => a.order - b.order);
+  
+  // Check for minimum gap between consecutive items
+  const minimumGap = 0.000001; // 1e-6
+  
+  for (let i = 0; i < sortedStickies.length - 1; i++) {
+    const gap = sortedStickies[i + 1].order - sortedStickies[i].order;
+    if (gap < minimumGap) {
+      return true;
+    }
+  }
+  
+  return false;
+}
+
+/**
+ * Rebalance order values for stickies in a column
+ * This spreads them out evenly to allow for future insertions
+ * @param stickies Array of stickies to rebalance
+ * @returns Array of updated stickies with new order values
+ */
+export function rebalanceOrders(stickies: StickyOrderInfo[]): StickyOrderInfo[] {
+  if (stickies.length === 0) return [];
+  
+  const sortedStickies = [...stickies].sort((a, b) => a.order - b.order);
+  const baseOrder = 1000.0;
+  const increment = 1000.0;
+  
+  return sortedStickies.map((sticky, index) => ({
+    ...sticky,
+    order: baseOrder + (index * increment)
+  }));
+}
+
+/**
+ * Generate initial order values for a batch of new stickies
+ * @param count Number of stickies to generate orders for
+ * @param startOrder Starting order value (default: 1000.0)
+ * @param increment Increment between orders (default: 1000.0)
+ * @returns Array of order values
+ */
+export function generateInitialOrders(
+  count: number, 
+  startOrder: number = 1000.0, 
+  increment: number = 1000.0
+): number[] {
+  return Array.from({ length: count }, (_, index) => startOrder + (index * increment));
+}

--- a/retro-ai/lib/socket-context.tsx
+++ b/retro-ai/lib/socket-context.tsx
@@ -9,6 +9,7 @@ interface MovementEvent {
   columnId: string | null;
   positionX?: number;
   positionY?: number;
+  order?: number;
   boardId?: string;
   userId: string;
   timestamp: number;

--- a/retro-ai/prisma/migrations/20250726182603_add_sticky_order_field/migration.sql
+++ b/retro-ai/prisma/migrations/20250726182603_add_sticky_order_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Sticky" ADD COLUMN     "order" DOUBLE PRECISION NOT NULL DEFAULT 0.0;

--- a/retro-ai/prisma/schema.prisma
+++ b/retro-ai/prisma/schema.prisma
@@ -94,6 +94,7 @@ model Sticky {
   column    Column?  @relation(fields: [columnId], references: [id])
   positionX Float
   positionY Float
+  order     Float    @default(0.0)
   authorId  String
   author    User     @relation(fields: [authorId], references: [id])
   editedBy  String[] @default([])

--- a/retro-ai/prisma/seed.ts
+++ b/retro-ai/prisma/seed.ts
@@ -119,9 +119,9 @@ async function main() {
         name: team.name,
         code: team.code,
         members: {
-          create: team.members.map(index => ({
+          create: team.members.map((index, memberIndex) => ({
             userId: createdUsers[index].id,
-            role: "MEMBER"
+            role: memberIndex === 0 ? "OWNER" : "MEMBER"
           }))
         }
       },

--- a/retro-ai/prisma/seed.ts
+++ b/retro-ai/prisma/seed.ts
@@ -1,8 +1,17 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, User } from "@prisma/client";
+import bcrypt from "bcryptjs";
 
 const prisma = new PrismaClient();
 
 async function main() {
+  // Check environment - only seed test data in development or staging
+  const nodeEnv = process.env.NODE_ENV || 'development';
+  // For now, we'll consider any non-production environment as suitable for test data
+  const isNonProduction = nodeEnv !== 'production';
+  
+  console.log('Current environment:', nodeEnv);
+
+  // Always seed templates regardless of environment
   // Create default templates
   const templates = [
     {
@@ -51,7 +60,239 @@ async function main() {
     });
   }
 
-  console.log("Seed data created successfully");
+  console.log("Templates seeded successfully");
+
+  // Seed test data only in non-production environments
+  if (!isNonProduction) {
+    console.log('Skipping test data seeding in production environment');
+    return;
+  }
+
+  console.log('Seeding test data for development/staging environment...');
+
+  // Create test users
+  const testUsers = [
+    { name: "Alice Johnson", email: "TestUser1@example.com", color: "#FFE066" },
+    { name: "Bob Smith", email: "TestUser2@example.com", color: "#FF6B9D" },
+    { name: "Charlie Brown", email: "TestUser3@example.com", color: "#4ECDC4" },
+    { name: "Diana Prince", email: "TestUser4@example.com", color: "#95E1D3" },
+    { name: "Ethan Hunt", email: "TestUser5@example.com", color: "#FFA07A" },
+    { name: "Fiona Shaw", email: "TestUser6@example.com", color: "#C3A6FF" },
+    { name: "George Wilson", email: "TestUser7@example.com", color: "#FFE066" },
+    { name: "Hannah Lee", email: "TestUser8@example.com", color: "#FF6B9D" },
+    { name: "Ian Malcolm", email: "TestUser9@example.com", color: "#4ECDC4" },
+    { name: "Julia Roberts", email: "TestUser10@example.com", color: "#95E1D3" },
+  ];
+
+  const hashedPassword = await bcrypt.hash("password", 10);
+  const createdUsers: User[] = [];
+
+  for (const user of testUsers) {
+    const createdUser = await prisma.user.upsert({
+      where: { email: user.email },
+      update: {},
+      create: {
+        name: user.name,
+        email: user.email,
+        password: hashedPassword,
+      },
+    });
+    createdUsers.push(createdUser);
+  }
+
+  console.log(`Created ${createdUsers.length} test users`);
+
+  // Create teams
+  const teamData = [
+    { name: "Alpha Team", code: "ALPHA001", members: [0, 1, 2, 3, 4] }, // Users 1-5
+    { name: "Beta Team", code: "BETA001", members: [5, 6, 7, 8, 9] },  // Users 6-10
+    { name: "Gamma Team", code: "GAMMA001", members: [1, 2, 3, 6, 8] }, // Users 2,3,4,7,9
+  ];
+
+  const createdTeams = [];
+
+  for (const team of teamData) {
+    const createdTeam = await prisma.team.upsert({
+      where: { code: team.code },
+      update: {},
+      create: {
+        name: team.name,
+        code: team.code,
+        members: {
+          create: team.members.map(index => ({
+            userId: createdUsers[index].id,
+            role: "MEMBER"
+          }))
+        }
+      },
+    });
+    createdTeams.push(createdTeam);
+  }
+
+  console.log(`Created ${createdTeams.length} teams`);
+
+  // Create boards with 4Ls template
+  const fourLsTemplate = await prisma.template.findUnique({
+    where: { name: "4Ls" }
+  });
+
+  if (!fourLsTemplate) {
+    throw new Error("4Ls template not found");
+  }
+
+  const boardData = [
+    { title: "Alpha Team Retrospective", teamId: createdTeams[0].id },
+    { title: "Beta Team Retrospective", teamId: createdTeams[1].id },
+    { title: "Gamma Team Retrospective", teamId: createdTeams[2].id },
+  ];
+
+  const createdBoards = [];
+
+  for (let i = 0; i < boardData.length; i++) {
+    const board = boardData[i];
+    
+    // Check if board already exists
+    const existingBoard = await prisma.board.findFirst({
+      where: {
+        title: board.title,
+        teamId: board.teamId
+      }
+    });
+
+    if (existingBoard) {
+      const boardWithColumns = await prisma.board.findUnique({
+        where: { id: existingBoard.id },
+        include: { columns: true }
+      });
+      if (boardWithColumns) {
+        createdBoards.push(boardWithColumns);
+      }
+    } else {
+      const createdBoard = await prisma.board.create({
+        data: {
+          title: board.title,
+          teamId: board.teamId,
+          templateId: fourLsTemplate.id,
+          createdById: createdUsers[0].id, // Use first user as creator
+          columns: {
+            create: [
+              { title: "Liked", order: 0, color: "#10B981" },
+              { title: "Learned", order: 1, color: "#3B82F6" },
+              { title: "Lacked", order: 2, color: "#F59E0B" },
+              { title: "Longed For", order: 3, color: "#8B5CF6" },
+            ]
+          }
+        },
+        include: {
+          columns: true
+        }
+      });
+      createdBoards.push(createdBoard);
+    }
+  }
+
+  console.log(`Created ${createdBoards.length} boards`);
+
+  // Witty AI/Claude Code related sticky note content
+  const stickyNoteContent = [
+    "Claude turned my spaghetti code into a five-star meal 🍝",
+    "AI pair programming: Like having a senior dev who never needs coffee",
+    "Debugging with Claude is faster than explaining the bug to a rubber duck",
+    "Finally, an AI that understands my variable names are perfect as is",
+    "Claude Code: Making me look smarter since 2024",
+    "Who needs Stack Overflow when you have an AI that actually understands context?",
+    "AI-assisted coding: Because my keyboard deserves a break too",
+    "Claude helped me refactor code I wrote at 3 AM and didn't understand at 9 AM",
+    "Claude writes better comments than I do, and I'm not even mad about it",
+    "My code reviews are now just me nodding along to Claude's suggestions",
+    "Claude found bugs I didn't know existed in code I didn't remember writing",
+    "Thanks to Claude, my imposter syndrome now has imposter syndrome",
+    "Claude: Turning 'it works on my machine' into 'it works everywhere'",
+    "AI coding assistant: Because copy-pasting from Stack Overflow is so 2023",
+    "Claude explains my code better than I explain my code",
+    "With Claude, every day is a code review where I actually learn something",
+    "Claude made me realize my 'clever' one-liners weren't that clever",
+    "My git commits are now 50% my code, 50% Claude's improvements",
+    "Claude: The only code reviewer that doesn't judge my naming conventions",
+    "AI pair programming: Now I can blame someone else for my bugs",
+    "Claude turned my hacky workaround into an actual solution",
+    "Thanks to Claude, my TODO comments are actually getting done",
+    "Claude writes unit tests that actually test things",
+    "My code is now Claude-approved and mother-approved",
+    "Claude: Making regex readable since never (but at least it tries)",
+    "With Claude, refactoring is no longer a four-letter word",
+    "Claude found performance issues I was strategically ignoring",
+    "AI coding: Because my rubber duck needed a PhD",
+    "Claude makes me feel like I know what I'm doing",
+    "My code now has fewer bugs than features, thanks Claude!",
+    "Claude: Turning coffee into clean code faster than ever",
+    "AI pair programming: Like having a mentor who never gets tired",
+    "Claude helped me understand my own code from last week",
+    "Thanks to Claude, my code now has a coherent architecture",
+    "Claude: Making technical debt payments since 2024",
+    "With Claude, every bug is a learning opportunity I actually understand",
+    "Claude turned my prototype into production-ready code",
+    "AI coding assistant: Because Google-fu only gets you so far",
+    "Claude makes me write documentation, and I'm grateful for it",
+    "My pull requests now get approved on the first try, thanks Claude!",
+    "Claude: The code whisperer we all needed",
+    "With Claude, I finally understand what SOLID principles mean",
+    "Claude helped me delete more code than I wrote, and that's a win",
+    "AI pair programming: Making me a 10x developer, 1x at a time",
+    "Claude found edge cases I didn't know had edges",
+  ];
+
+  // Create sticky notes
+  let stickyNoteIndex = 0;
+  let totalStickies = 0;
+
+  for (let boardIndex = 0; boardIndex < createdBoards.length; boardIndex++) {
+    const board = createdBoards[boardIndex];
+    const team = createdTeams[boardIndex];
+    
+    // Get team members for this board
+    const teamMembers = await prisma.user.findMany({
+      where: {
+        teams: {
+          some: {
+            teamId: team.id
+          }
+        }
+      }
+    });
+
+    // Each user creates 3 sticky notes
+    for (const user of teamMembers) {
+      const userIndex = createdUsers.findIndex(u => u.id === user.id);
+      const userColor = testUsers[userIndex].color;
+      
+      for (let noteCount = 0; noteCount < 3; noteCount++) {
+        const column = board.columns![noteCount % board.columns!.length];
+        const content = stickyNoteContent[stickyNoteIndex % stickyNoteContent.length];
+        stickyNoteIndex++;
+        
+        // Calculate position within column (distribute notes)
+        const positionX = column.order * 300 + 50 + (noteCount * 20); // Spread horizontally
+        const positionY = 100 + (stickyNoteIndex * 30) % 400; // Spread vertically
+        
+        await prisma.sticky.create({
+          data: {
+            content,
+            color: userColor,
+            columnId: column.id,
+            boardId: board.id,
+            authorId: user.id,
+            positionX,
+            positionY,
+          }
+        });
+        totalStickies++;
+      }
+    }
+  }
+
+  console.log(`Created ${totalStickies} sticky notes`);
+  console.log("Test data seeded successfully");
 }
 
 main()

--- a/retro-ai/scripts/fix-order-values.ts
+++ b/retro-ai/scripts/fix-order-values.ts
@@ -1,0 +1,124 @@
+#!/usr/bin/env tsx
+
+/**
+ * Data Migration Script: Fix Order Values for Existing Sticky Notes
+ * 
+ * This script assigns proper order values to all existing sticky notes
+ * that currently have order = 0.0 after the schema migration.
+ * 
+ * Strategy:
+ * 1. Group stickies by column (including unassigned)
+ * 2. Order them by createdAt timestamp within each group
+ * 3. Assign order values like 1000.0, 2000.0, 3000.0 etc.
+ * 
+ * Usage: npx tsx scripts/fix-order-values.ts
+ */
+
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+async function fixStickyOrderValues() {
+  console.log('🔄 Starting sticky note order value migration...');
+  
+  try {
+    // Get all stickies grouped by board and column
+    const boards = await prisma.board.findMany({
+      include: {
+        stickies: {
+          orderBy: { createdAt: 'asc' },
+          include: {
+            column: true
+          }
+        }
+      }
+    });
+
+    let totalUpdated = 0;
+
+    for (const board of boards) {
+      console.log(`📋 Processing board: ${board.title} (${board.stickies.length} stickies)`);
+      
+      // Group stickies by columnId (null for unassigned)
+      const stickyGroups = new Map<string | null, typeof board.stickies>();
+      
+      for (const sticky of board.stickies) {
+        const columnId = sticky.columnId;
+        if (!stickyGroups.has(columnId)) {
+          stickyGroups.set(columnId, []);
+        }
+        stickyGroups.get(columnId)!.push(sticky);
+      }
+
+      // Process each group
+      for (const [columnId, stickies] of stickyGroups) {
+        const columnName = columnId ? stickies[0]?.column?.title || 'Unknown Column' : 'Unassigned';
+        console.log(`  📝 Processing ${columnName}: ${stickies.length} stickies`);
+        
+        // Sort by createdAt to maintain chronological order
+        stickies.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+        
+        // Update each sticky with proper order values
+        for (let i = 0; i < stickies.length; i++) {
+          const sticky = stickies[i];
+          const newOrder = 1000.0 + (i * 1000.0); // 1000, 2000, 3000, etc.
+          
+          await prisma.sticky.update({
+            where: { id: sticky.id },
+            data: { order: newOrder }
+          });
+          
+          console.log(`    ✅ Updated sticky "${sticky.content.substring(0, 30)}..." order: ${newOrder}`);
+          totalUpdated++;
+        }
+      }
+    }
+
+    // Verify the updates
+    const verification = await prisma.sticky.groupBy({
+      by: ['order'],
+      _count: true,
+      orderBy: { order: 'asc' }
+    });
+
+    console.log('\n📊 Order value distribution after migration:');
+    for (const group of verification) {
+      console.log(`  Order ${group.order}: ${group._count} stickies`);
+    }
+
+    console.log(`\n✅ Migration completed successfully!`);
+    console.log(`📈 Total stickies updated: ${totalUpdated}`);
+    
+    // Check for any remaining zero-order stickies
+    const zeroOrderCount = await prisma.sticky.count({
+      where: { order: 0.0 }
+    });
+    
+    if (zeroOrderCount > 0) {
+      console.log(`⚠️  Warning: ${zeroOrderCount} stickies still have order = 0.0`);
+    } else {
+      console.log(`🎉 All stickies now have proper order values!`);
+    }
+
+  } catch (error) {
+    console.error('❌ Migration failed:', error);
+    throw error;
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+// Run the migration
+if (require.main === module) {
+  fixStickyOrderValues()
+    .then(() => {
+      console.log('Migration script completed.');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('Migration script failed:', error);
+      process.exit(1);
+    });
+}
+
+export { fixStickyOrderValues };


### PR DESCRIPTION
## Staging Alpha Release 

Deploy the latest batch of improvements and fixes from develop to staging for testing.

## Major Changes Included

### 🎯 **Issue #156: Move Create Note Button to Header**
- Moved floating create note button to board header to prevent toast overlap
- Implemented responsive design for mobile/desktop compatibility
- Split server/client components for proper Next.js architecture
- All tests updated and passing

### 🚀 **Dashboard Optimization (#151, #152, #154, #155)**
- Removed Recent Activity section for cleaner interface
- Fixed Total Boards and Teams count display
- Implemented smart back navigation
- Unified dashboard styling and removed redundant sections

### 🔧 **UI/UX Improvements**
- **Issue #148**: Improved remote sticky note animations with shrink-to-square effect
- **Issue #150**: Fixed persistent browser scrollbar issues
- **Issue #123**: Fixed remote animations z-index conflicts with modals

### 🎮 **Real-time Collaboration Enhancements**
- **Issue #125**: Added socket integration for real-time column creation
- **Issue #80**: Implemented consistent sticky note ordering across users
- Enhanced WebSocket synchronization and documentation

### 🛠 **Infrastructure & Development**
- **Issue #145**: Added comprehensive database seeding for development
- **Issue #137**: GitHub Action for cleaning up old staging/alpha tags
- **Issue #120**: Fixed logout redirect for dynamic hostnames

## Commits (38 total)
- 13 merged pull requests
- Multiple bug fixes and feature enhancements
- Comprehensive test coverage updates
- Documentation improvements

## Testing Focus
- Header button functionality on mobile/desktop
- Toast message behavior (should no longer overlap)
- Dashboard navigation and statistics
- Real-time collaboration features
- Animation performance and z-index behavior
- Database seeding and authentication flows

## Version
This will create an alpha release with format: `v0.1.0-alpha.TIMESTAMP+COMMIT`

🤖 Generated with [Claude Code](https://claude.ai/code)