### PR TITLE
Fix docker-compose to run database migrations on startup

### DIFF
--- a/retro-ai/docker-compose.yml
+++ b/retro-ai/docker-compose.yml
@@ -10,8 +10,10 @@ services:
       - NEXTAUTH_URL=http://localhost:3000
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET:-your-secret-key-change-this}
       - DATABASE_URL=postgresql://retroai:password@db:5432/retroai
+    command: sh -c "npx prisma migrate deploy && node server.js"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     volumes:
       - .env:/app/.env  # Mount environment file
     networks:
@@ -28,6 +30,11 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./prisma/schema.prisma:/docker-entrypoint-initdb.d/schema.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U retroai -d retroai"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
     networks:
       - retro-network
 


### PR DESCRIPTION
## Summary
- Fixes issue #163 where database migrations weren't being applied during Coolify deployments
- Adds migration command to docker-compose.yml app service to run `npx prisma migrate deploy` before starting the server
- Adds PostgreSQL health check to ensure database is ready before app starts
- Ensures proper dependency ordering between app and database services

## Changes
- Updated `docker-compose.yml` to include migration command in app service
- Added health check dependency configuration using `condition: service_healthy`
- Added PostgreSQL health check to db service using `pg_isready`

## Test plan
- [ ] Verify docker-compose builds and starts successfully
- [ ] Confirm migrations are applied during container startup
- [ ] Test that app waits for database to be healthy before starting
- [ ] Deploy to staging and verify database migrations are applied

Closes #163

🤖 Generated with [Claude Code](https://claude.ai/code)