### PR TITLE
Move tsx to production dependencies for database seeding

### DIFF
--- a/retro-ai/package.json
+++ b/retro-ai/package.json
@@ -56,6 +56,7 @@
     "socket.io-client": "^4.8.1",
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.1",
+    "tsx": "^4.20.3",
     "zod": "^4.0.5"
   },
   "devDependencies": {
@@ -74,7 +75,6 @@
     "jest-environment-jsdom": "^30.0.4",
     "tailwindcss": "^4",
     "ts-node": "^10.9.2",
-    "tsx": "^4.20.3",
     "tw-animate-css": "^1.3.5",
     "typescript": "^5"
   },


### PR DESCRIPTION
## Summary
Fixes database seeding failing in production/staging environments by moving `tsx` from devDependencies to dependencies.

## Problem
Database seeding was failing with:
```
Error: Command failed with ENOENT: tsx prisma/seed.ts
spawn tsx ENOENT
```

This occurred because `tsx` was only available in devDependencies, but the Prisma seed command requires it in production environments.

## Solution
- Moved `tsx` from devDependencies to dependencies in package.json
- Verified `npm run db:seed` now works correctly
- Tested seeding creates all expected test data (users, teams, boards, sticky notes)

## Test Results
✅ Database seeding now works successfully:
```
Created 10 test users
Created 3 teams  
Created 3 boards
Created 45 sticky notes
Test data seeded successfully
```

## Test plan
- [ ] Verify seeding works in staging environment
- [ ] Confirm production builds include tsx dependency
- [ ] Test `npm run migrate:reset` works end-to-end

Closes #166

🤖 Generated with [Claude Code](https://claude.ai/code)