### PR TITLE
Fix: Remove redundant npm run build from Docker Compose commands

### DIFF
--- a/retro-ai/docker-compose.nginx.yml
+++ b/retro-ai/docker-compose.nginx.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - NODE_ENV=${NODE_ENV:-production}
       - DATABASE_URL=postgresql://${DB_USER:-retroai}:${DB_PASSWORD:-changeme}@db:5432/${DB_NAME:-retroai}
-    command: sh -c "npx prisma migrate deploy && npm run build && node server.js"
+    command: sh -c "npx prisma migrate deploy && node server.js"
     depends_on:
       db:
         condition: service_healthy

--- a/retro-ai/docker-compose.yml
+++ b/retro-ai/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - EMAIL_FROM=${EMAIL_FROM}
       - EMAIL_FROM_NAME=${EMAIL_FROM_NAME}
       - SOCKET_PORT=${SOCKET_PORT:-3001}
-    command: sh -c "npx prisma migrate deploy && npm run build && node server.js"
+    command: sh -c "npx prisma migrate deploy && node server.js"
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
Fixed Docker container startup failures by removing redundant `npm run build` command from Docker Compose configurations.

## Problem
Docker containers were failing to start with Next.js build error \"cannot find pages or app directory\" because:

- Docker Compose was running: `npx prisma migrate deploy && npm run build && node server.js`
- The Dockerfile uses multi-stage builds where the app is already built in the builder stage
- Runtime container only contains the built `.next` directory, not the source code needed for building
- `npm run build` was failing because source files (`app/` directory) are not copied to the runtime stage

## Root Cause
The `npm run build` command in docker-compose.yml was redundant and incorrect because:
- The application is already built during the Docker build process (builder stage)
- The runtime container should only run migrations and start the server
- Source code is not available in the final runtime stage

## Solution
Removed `npm run build` from Docker Compose commands:

**Before:**
```yaml
command: sh -c \"npx prisma migrate deploy && npm run build && node server.js\"
```

**After:**
```yaml
command: sh -c \"npx prisma migrate deploy && node server.js\"
```

## Changes Made
- ✅ Fixed `docker-compose.yml` (Cloudflare version)
- ✅ Fixed `docker-compose.nginx.yml` (nginx version) 
- ✅ Verified `docker-compose.override.yml` is correct (uses `npm run dev` for development)

## Testing
- ✅ ESLint passed (only existing warnings)
- ✅ TypeScript type checking passed
- ✅ Both compose files now have consistent command structure

## Impact
- **Fixes container startup failures** in Coolify and other deployments
- **Eliminates redundant build step** (already done in Dockerfile)
- **Faster container startup** time
- **Consistent with Dockerfile CMD** approach

## Verification
The Dockerfile already has the correct CMD:
```dockerfile
CMD [\"sh\", \"-c\", \"npx prisma migrate deploy && node server.js\"]
```

Docker Compose commands now match this pattern.

Closes #210

🤖 Generated with [Claude Code](https://claude.ai/code)